### PR TITLE
[VIT-2798] Improve GATTMeter error handling and device compatibility

### DIFF
--- a/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/BloodPressureReader1810.kt
+++ b/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/BloodPressureReader1810.kt
@@ -16,8 +16,8 @@ private val bloodPressureMeasurementCharacteristicUUID =
     UUID.fromString("00002A35-0000-1000-8000-00805f9b34fb")
 
 interface BloodPressureReader {
-    fun pair(): Flow<Boolean>
-    fun read(): Flow<List<BloodPressureSample>>
+    suspend fun pair()
+    suspend fun read(): List<BloodPressureSample>
 }
 
 class BloodPressureReader1810(

--- a/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/GATTMeter.kt
+++ b/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/GATTMeter.kt
@@ -64,7 +64,7 @@ abstract class GATTMeter<Sample>(
             .timeout(15000)
             .useAutoConnect(false)
             .fail { _, status ->
-                logError("connect", status)
+                vitalLogger.logI("Failed to connect (status code = $status)")
 
                 if (!continuation.isActive) {
                     vitalLogger.logI("Inactive continuation has received connect fail callback for ${scannedDevice.name}")
@@ -157,7 +157,7 @@ abstract class GATTMeter<Sample>(
             BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
         )
             .fail { _, status ->
-                logError("writeCharacteristic", status)
+                vitalLogger.logI("Failed to write characteristic (status code = $status)")
                 this.close(BluetoothError("Failed to write to the RACP characteristic."))
             }
             .done { vitalLogger.logI("Successfully initiated the read operation via an RACP write.") }
@@ -168,7 +168,7 @@ abstract class GATTMeter<Sample>(
     private fun bond(onDone: () -> Unit, onFail: (Int) -> Unit) {
         ensureBond()
             .fail { _, status ->
-                logError("bond", status)
+                vitalLogger.logI("Failed to bond (status code = $status)")
                 onFail(status)
             }
             .done {
@@ -236,9 +236,5 @@ abstract class GATTMeter<Sample>(
             measurementCharacteristic = null
             deviceReady.value = false
         }
-    }
-
-    private fun logError(context: String, status: Int) {
-        vitalLogger.logI("Error in $context for ${scannedDevice.name} with status $status")
     }
 }

--- a/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/GlucoseMeter1808.kt
+++ b/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/GlucoseMeter1808.kt
@@ -18,8 +18,8 @@ private val glucoseMeasurementCharacteristicUUID =
     UUID.fromString("00002A18-0000-1000-8000-00805f9b34fb")
 
 interface GlucoseMeter {
-    fun pair(): Flow<Boolean>
-    fun read(): Flow<List<QuantitySamplePayload>>
+    suspend fun pair()
+    suspend fun read(): List<QuantitySamplePayload>
 }
 
 class GlucoseMeter1808(


### PR DESCRIPTION
1. Align with iOS SDK API
   * `DevicesManager` returns `GlucoseMeter` and `BloodPressureReader` objects, each of which offer `pair()` and `read()`.
   * Removed `DevicesManager.pair()`.
   * `read()` now attempts to pair with the BLE meter if the device hasn't already done so.

2. `pair()` and `read()` are now suspend (async) functions, since they either return one value or throw an exception.


4. Improved error propagation where all cases of the underlying BleManager request failure now throws a `BluetoothError` exception. Some of these previously are eaten up silently.

5. We now proactively disconnect after successfully reading samples. Accu-Check for example seems to rely on disconnection as a cue to prompt "transfer completed" to users.

6. Fixed a scenario where corrupted system BLE device cache causes a crash in `isRequiredServiceSupported` (where the expected BLE service does not exist).