### PR TITLE
[VIT-2862] Fix GZip request interceptor

### DIFF
--- a/VitalClient/src/main/java/io/tryvital/client/dependencies/Dependencies.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/dependencies/Dependencies.kt
@@ -70,8 +70,7 @@ class Dependencies(
                 }
                 .writeTimeout(60, TimeUnit.SECONDS)
                 .readTimeout(60, TimeUnit.SECONDS)
-                // TODO: [VIT-2862] GZip not working correctly.
-                //.addInterceptor(GzipRequestInterceptor())
+                .addInterceptor(GzipRequestInterceptor())
                 .addNetworkInterceptor(ApiKeyInterceptor(apiKey))
                 .addInterceptor(loggingInterceptor)
                 .build()

--- a/VitalClient/src/main/java/io/tryvital/client/dependencies/Dependencies.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/dependencies/Dependencies.kt
@@ -9,7 +9,7 @@ import io.tryvital.client.BuildConfig
 import io.tryvital.client.Environment
 import io.tryvital.client.Region
 import io.tryvital.client.utils.ApiKeyInterceptor
-import io.tryvital.client.utils.GzipRequestInterceptor
+import io.tryvital.client.utils.VitalRequestInterceptor
 import io.tryvital.client.utils.VitalLogger
 import okhttp3.Cache
 import okhttp3.OkHttpClient
@@ -70,7 +70,7 @@ class Dependencies(
                 }
                 .writeTimeout(60, TimeUnit.SECONDS)
                 .readTimeout(60, TimeUnit.SECONDS)
-                .addInterceptor(GzipRequestInterceptor())
+                .addInterceptor(VitalRequestInterceptor())
                 .addNetworkInterceptor(ApiKeyInterceptor(apiKey))
                 .addInterceptor(loggingInterceptor)
                 .build()

--- a/VitalClient/src/main/java/io/tryvital/client/utils/ApiKeyInterceptor.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/utils/ApiKeyInterceptor.kt
@@ -5,7 +5,10 @@ import okhttp3.Response
 
 class ApiKeyInterceptor(val apiKey: String): Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        val request = chain.request().newBuilder().addHeader("x-vital-api-key", apiKey).build()
+        val request = chain.request().newBuilder()
+            .addHeader("x-vital-api-key", apiKey)
+            .addHeader("x-vital-ios-sdk-version", "0.9.3")
+            .build()
         return chain.proceed(request)
     }
 }

--- a/VitalClient/src/main/java/io/tryvital/client/utils/ApiKeyInterceptor.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/utils/ApiKeyInterceptor.kt
@@ -5,10 +5,7 @@ import okhttp3.Response
 
 class ApiKeyInterceptor(val apiKey: String): Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        val request = chain.request().newBuilder()
-            .addHeader("x-vital-api-key", apiKey)
-            .addHeader("x-vital-ios-sdk-version", "0.9.3")
-            .build()
+        val request = chain.request().newBuilder().addHeader("x-vital-api-key", apiKey).build()
         return chain.proceed(request)
     }
 }


### PR DESCRIPTION
`GzipRequestInterceptor` attempts to Gzip every single requests. But only certain POST endpoints support Gzipped request.

* Renamed `GzipRequestInterceptor` to `VitalRequestInterceptor`.
* Prevent `VitalRequestInterceptor` from gzipping requests except for a subset of endpoints.
* `VitalRequestInterceptor` now injects the `x-vital-ios-sdk-version` header into all API requests (subject to change; added for development testing)