### PR TITLE
[VIT-2857] HC Permission API for parity with iOS ask(read:write:).

### DIFF
--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/Utils.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/Utils.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.health.connect.client.request.ChangesTokenRequest
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
+import io.tryvital.vitalhealthconnect.model.VitalResource
+import io.tryvital.vitalhealthconnect.model.WritableVitalResource
 
 internal const val prefsFileName: String = "vital_health_connect_prefs"
 internal const val encryptedPrefsFileName: String = "safe_vital_health_connect_prefs"
@@ -15,11 +17,13 @@ object SecurePrefKeys{
     internal const val userIdKey = "userId"
 }
 
-object UnSecurePrefKeys{
+object UnSecurePrefKeys {
     internal const val loggerEnabledKey = "loggerEnabled"
     internal const val changeTokenKey = "changeToken"
     internal const val syncOnAppStartKey = "syncOnAppStartKey"
     internal const val numberOfDaysToBackFillKey = "numberOfDaysToBackFill"
+    internal fun readResourceGrant(resource: VitalResource) = "resource.read.$resource"
+    internal fun writeResourceGrant(resource: WritableVitalResource) = "resource.write.$resource"
 }
 
 internal suspend fun saveNewChangeToken(context: Context) {

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalPermissionRequestContract.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalPermissionRequestContract.kt
@@ -1,0 +1,85 @@
+package io.tryvital.vitalhealthconnect
+
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.health.connect.client.PermissionController
+import io.tryvital.client.utils.VitalLogger
+import io.tryvital.vitalhealthconnect.model.*
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+
+class VitalPermissionRequestContract(
+    private val readResources: Set<VitalResource>,
+    private val writeResources: Set<WritableVitalResource>,
+    private val manager: VitalHealthConnectManager,
+    private val taskScope: CoroutineScope,
+): ActivityResultContract<Unit, Deferred<PermissionOutcome>>() {
+    private val contract = PermissionController.createRequestPermissionResultContract()
+
+    override fun getSynchronousResult(
+        context: Context,
+        input: Unit
+    ): SynchronousResult<Deferred<PermissionOutcome>>? {
+        if (VitalHealthConnectManager.isAvailable(context) != HealthConnectAvailability.Installed) {
+            return SynchronousResult(CompletableDeferred(PermissionOutcome.HealthConnectUnavailable))
+        }
+
+        val grantedPermissions = contract.getSynchronousResult(context, permissionsToRequest())?.value
+
+        return if (grantedPermissions != null) {
+            processGrantedPermissionsAsync(grantedPermissions).let(::SynchronousResult)
+        } else {
+            null
+        }
+    }
+
+    override fun createIntent(context: Context, input: Unit): Intent
+        = contract.createIntent(context, permissionsToRequest())
+
+    @Suppress("DeferredIsResult")
+    override fun parseResult(resultCode: Int, intent: Intent?): Deferred<PermissionOutcome> {
+        val grantedPermissions = contract.parseResult(resultCode, intent)
+
+        if (intent == null) {
+            return CompletableDeferred(
+                PermissionOutcome.Failure(cause = IllegalStateException("Missing intent in parseResult."))
+            )
+        }
+
+        return processGrantedPermissionsAsync(grantedPermissions)
+    }
+
+    private fun processGrantedPermissionsAsync(permissions: Set<String>): Deferred<PermissionOutcome> {
+        val readGrants = readResources
+            .filter { permissions.containsAll(manager.permissionsRequiredToSyncResources(setOf(it))) }
+            .toSet()
+
+        val writeGrants = writeResources
+            .filter { permissions.containsAll(manager.permissionsRequiredToWriteResources(setOf(it))) }
+            .toSet()
+
+        manager.sharedPreferences.edit().run {
+            readGrants.forEach { putBoolean(UnSecurePrefKeys.readResourceGrant(it), true) }
+            writeGrants.forEach { putBoolean(UnSecurePrefKeys.writeResourceGrant(it), true) }
+            apply()
+        }
+
+        VitalLogger.getOrCreate().logI("[processGrantedPermissions] Saved read grants: ${readGrants.joinToString(", ")}; write grants = ${writeGrants.joinToString(", ")}")
+
+        return taskScope.async {
+            // The activity result reports only permissions granted in this UI interaction.
+            // Since we have VitalResources that are an aggregate of multiple record types, we need
+            // to recompute based on the full set of permissions.
+            manager.checkAndUpdatePermissions()
+            PermissionOutcome.Success
+        }
+    }
+
+    private fun permissionsToRequest(): Set<String> {
+        return manager.permissionsRequiredToWriteResources(this.writeResources) +
+                manager.permissionsRequiredToSyncResources(this.readResources)
+    }
+}

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/PermissionOutcome.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/PermissionOutcome.kt
@@ -1,0 +1,7 @@
+package io.tryvital.vitalhealthconnect.model
+
+sealed interface PermissionOutcome {
+    object Success: PermissionOutcome
+    class Failure(cause: Throwable?): PermissionOutcome
+    object HealthConnectUnavailable: PermissionOutcome
+}

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/WritableVitalResource.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/WritableVitalResource.kt
@@ -3,4 +3,23 @@ package io.tryvital.vitalhealthconnect.model
 sealed class WritableVitalResource(val name: String) {
     object Glucose : WritableVitalResource("glucose")
     object Water : WritableVitalResource("water")
+
+    override fun toString(): String {
+        return name
+    }
+
+    companion object {
+        @Suppress("unused")
+        fun values(): Array<WritableVitalResource> {
+            return arrayOf(Glucose, Water)
+        }
+
+        fun valueOf(value: String): WritableVitalResource {
+            return when (value) {
+                "glucose" -> Glucose
+                "water" -> Water
+                else -> throw IllegalArgumentException("No object io.tryvital.vitalhealthconnect.model.HealthResource.$value")
+            }
+        }
+    }
 }


### PR DESCRIPTION
Create an Android equivalent of these two iOS SDK APIs:

* `VitalHealthKitClient.ask(readPermissions:writePermissions:)` where one can specify a set of VitalResource and a set of WritableVitalResource.

* `VitalHealthKitClient.hasAskedForPermission` given a VitalResource.

In order to support these two APIs:

* We now track the permission status in `SharedPreferences` of each `VitalResource` and `WritableVitalResource`.

* A permission check is scheduled every time VitalHealthConnectManager is initialised, so as to detect permission grants and revocations done outside the SDK host app (in Health Connect's app).


### API signature differences

Note that the signature of the API is slightly different due to platform SDK design differences.

HealthKit permission requests are no different from a normal async method call. On the other hand, Android here specifically requires these to be modelled as `ActivityResultContract<Input, Output>`, and can only be launched in specific UI contexts (Activity/Fragment/Compose UI). This makes it very difficult to mimic the exact same shape.

Flutter & RN will bridge this difference in their respective interop layer — the Flutter/React bridge will provide us the appropriate `Activity` where we can launch our permission request from.


### Updated example apps
Updated the layout, and made the "Request" button permanently visible.

| Partially Granted State | HC Prompt | Fully Granted State |
| ----- | ----- | ----- |
| ![Screenshot_20230427_201603_Vital sample](https://user-images.githubusercontent.com/11806295/234859946-24a9f843-cf39-49fd-bc10-cce67662723f.png)|  ![Screenshot_20230427_201615_Health Connect](https://user-images.githubusercontent.com/11806295/234859963-4f44ca78-823f-4813-9dc6-1574b1b41f5b.jpg) | ![Screenshot_20230427_201622_Vital sample](https://user-images.githubusercontent.com/11806295/234859959-8ff36abc-05c6-4caf-8660-47649a1409d3.png) |

