### PR TITLE
[VIT-2945] Introduce provider slugs & update request models

### DIFF
--- a/VitalClient/src/main/java/io/tryvital/client/dependencies/Dependencies.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/dependencies/Dependencies.kt
@@ -2,12 +2,16 @@ package io.tryvital.client.dependencies
 
 import android.content.Context
 import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
+import com.squareup.moshi.Json
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import com.squareup.moshi.rawType
 import io.tryvital.client.BuildConfig
 import io.tryvital.client.Environment
 import io.tryvital.client.Region
+import io.tryvital.client.services.data.ManualProviderSlug
+import io.tryvital.client.services.data.ProviderSlug
 import io.tryvital.client.utils.ApiKeyInterceptor
 import io.tryvital.client.utils.VitalRequestInterceptor
 import io.tryvital.client.utils.LocalDateJsonAdapter
@@ -95,6 +99,8 @@ class Dependencies(
             .add(KotlinJsonAdapterFactory())
             .add(Date::class.java, Rfc3339DateJsonAdapter())
             .add(LocalDate::class.java, LocalDateJsonAdapter)
+            .add(ProviderSlug::class.java, ProviderSlug.jsonAdapter)
+            .add(ManualProviderSlug::class.java, ManualProviderSlug.jsonAdapter)
             .build()
 
         internal fun resolveUrl(region: Region, environment: Environment): String {
@@ -122,7 +128,9 @@ class Dependencies(
         ): Converter<*, String>? {
             return if (type === Date::class.java) {
                 DateQueryConverter.INSTANCE
-            } else null
+            } else {
+                null
+            }
         }
 
         private class DateQueryConverter : Converter<Date, String> {

--- a/VitalClient/src/main/java/io/tryvital/client/services/LinkService.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/LinkService.kt
@@ -35,7 +35,6 @@ interface LinkService {
     @POST("link/provider/manual/{provider}")
     suspend fun manualProvider(
         @Path("provider") provider: ManualProviderSlug,
-        @Header("LinkToken") linkToken: String,
         @Body request: ManualProviderRequest,
     ): ManualProviderResponse
 

--- a/VitalClient/src/main/java/io/tryvital/client/services/LinkService.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/LinkService.kt
@@ -34,7 +34,7 @@ interface LinkService {
 
     @POST("link/provider/manual/{provider}")
     suspend fun manualProvider(
-        @Path("provider") provider: String,
+        @Path("provider") provider: ManualProviderSlug,
         @Header("LinkToken") linkToken: String,
         @Body request: ManualProviderRequest,
     ): ManualProviderResponse

--- a/VitalClient/src/main/java/io/tryvital/client/services/UserService.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/UserService.kt
@@ -27,7 +27,7 @@ interface UserService {
     @DELETE("user/{user_id}/{provider}")
     suspend fun deregisterProvider(
         @Path("user_id") userId: String,
-        @Path("provider") provider: String,
+        @Path("provider") provider: ProviderSlug,
     ): DeregisterProviderResponse
 
     @POST("user/refresh/{user_id}")

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Link.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Link.kt
@@ -28,7 +28,7 @@ data class ManualProviderRequest(
     @Json(name = "user_id")
     val userId: String,
     @Json(name = "provider_id")
-    val providerId: String,
+    val providerId: String? = null,
 )
 
 data class CreateLinkResponse(

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/ProviderSlug.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/ProviderSlug.kt
@@ -1,0 +1,24 @@
+@file:Suppress("unused")
+
+package io.tryvital.client.services.data
+
+import com.squareup.moshi.Json
+
+enum class ManualProviderSlug {
+    @Json(name = "beurer_ble")
+    BeurerBLE,
+    @Json(name = "omron_ble")
+    OmronBLE,
+    @Json(name = "accuchek_ble")
+    AccuchekBLE,
+    @Json(name = "contour_ble")
+    ContourBLE,
+    @Json(name = "freestyle_libre_ble")
+    LibreBLE,
+    @Json(name = "manual")
+    Manual,
+    @Json(name = "apple_health_kit")
+    AppleHealthKit,
+    @Json(name = "health_connect")
+    HealthConnect,
+}

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/ProviderSlug.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/ProviderSlug.kt
@@ -3,22 +3,73 @@
 package io.tryvital.client.services.data
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.adapters.EnumJsonAdapter
 
+@JsonClass(generateAdapter = false)
 enum class ManualProviderSlug {
-    @Json(name = "beurer_ble")
-    BeurerBLE,
-    @Json(name = "omron_ble")
-    OmronBLE,
-    @Json(name = "accuchek_ble")
-    AccuchekBLE,
-    @Json(name = "contour_ble")
-    ContourBLE,
-    @Json(name = "freestyle_libre_ble")
-    LibreBLE,
-    @Json(name = "manual")
-    Manual,
-    @Json(name = "apple_health_kit")
-    AppleHealthKit,
-    @Json(name = "health_connect")
-    HealthConnect,
+    @Json(name = "beurer_ble") BeurerBLE,
+    @Json(name = "omron_ble") OmronBLE,
+    @Json(name = "accuchek_ble") AccuchekBLE,
+    @Json(name = "contour_ble") ContourBLE,
+    @Json(name = "freestyle_libre_ble") LibreBLE,
+    @Json(name = "manual") Manual,
+    @Json(name = "apple_health_kit") AppleHealthKit,
+    @Json(name = "health_connect") HealthConnect;
+
+    // Use the Json name also when converting to string.
+    // This is intended for Retrofit request parameter serialization.
+    override fun toString() = getJsonName(this)
+
+    companion object {
+        val jsonAdapter: EnumJsonAdapter<ManualProviderSlug>
+            get() = EnumJsonAdapter.create(ManualProviderSlug::class.java)
+    }
 }
+
+@JsonClass(generateAdapter = false)
+enum class ProviderSlug {
+    Unrecognized,
+
+    // Cloud
+    @Json(name = "beurer_api") Beurer,
+    @Json(name = "ihealth") IHealth,
+    @Json(name = "freestyle_libre") Libre,
+    @Json(name = "oura") Oura,
+    @Json(name = "garmin") Garmin,
+    @Json(name = "fitbit") Fitbit,
+    @Json(name = "whoop") Whoop,
+    @Json(name = "strava") Strava,
+    @Json(name = "renpho") Renpho,
+    @Json(name = "peloton") Peloton,
+    @Json(name = "wahoo") Wahoo,
+    @Json(name = "zwift") Zwift,
+    @Json(name = "eight_sleep") EightSleep,
+    @Json(name = "withings") Withings,
+    @Json(name = "google_fit") GoogleFit,
+    @Json(name = "hammerhead") Hammerhead,
+    @Json(name = "dexcom") Dexcom,
+    @Json(name = "my_fitness_pal") MyFitnessPal,
+
+    // Manual
+    @Json(name = "beurer_ble") BeurerBLE,
+    @Json(name = "omron_ble") OmronBLE,
+    @Json(name = "accuchek_ble") AccuchekBLE,
+    @Json(name = "contour_ble") ContourBLE,
+    @Json(name = "freestyle_libre_ble") LibreBLE,
+    @Json(name = "manual") Manual,
+    @Json(name = "apple_health_kit") AppleHealthKit,
+    @Json(name = "health_connect") HealthConnect;
+
+    // Use the Json name also when converting to string.
+    // This is intended for Retrofit request parameter serialization.
+    override fun toString() = getJsonName(this)
+
+    companion object {
+        val jsonAdapter: EnumJsonAdapter<ProviderSlug>
+            get() = EnumJsonAdapter.create(ProviderSlug::class.java).withUnknownFallback(Unrecognized)
+    }
+}
+
+private fun getJsonName(value: Enum<*>) = value.javaClass
+    .getField(value.name).getAnnotation(Json::class.java)?.name ?: value.name

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Sleep.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Sleep.kt
@@ -39,7 +39,7 @@ data class SleepData(
     val averageHrv: Double?,
     @Json(name = "respiratory_rate")
     val respiratoryRate: Double?,
-    val source: Source?,
+    val source: Source,
     @Json(name = "sleep_stream")
     val sleepStream: SleepStreamResponse?,
 )

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Summary.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Summary.kt
@@ -7,7 +7,7 @@ data class SummaryPayload<T>(
     @Json(name = "stage")
     val stage: String,
     @Json(name = "provider")
-    val provider: String,
+    val provider: ManualProviderSlug,
     @Json(name = "start_date")
     val startDate: Date?,
     @Json(name = "end_date")

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Timeseries.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Timeseries.kt
@@ -7,7 +7,7 @@ data class TimeseriesPayload<T> (
     @Json(name = "stage")
     val stage: String,
     @Json(name = "provider")
-    val provider: String,
+    val provider: ManualProviderSlug,
     @Json(name = "start_date")
     val startDate: Date?,
     @Json(name = "end_date")

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/User.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/User.kt
@@ -5,28 +5,28 @@ import java.util.*
 
 data class User(
     @Json(name = "user_id")
-    val userId: String?,
+    val userId: String,
     @Json(name = "user_key")
     val userKey: String?,
     @Json(name = "team_id")
-    val teamId: String?,
+    val teamId: String,
     @Json(name = "client_user_id")
-    val clientUserId: String?,
+    val clientUserId: String,
     @Json(name = "created_on")
-    val createdOn: Date?,
+    val createdOn: Date,
     @Json(name = "connected_sources")
-    val connectedSources: List<ConnectedSource>?
+    val connectedSources: List<ConnectedSource>
 )
 
 data class ConnectedSource(
-    val source: Source?,
+    val source: Source,
     @Json(name = "created_on")
-    val createdOn: Date?
+    val createdOn: Date
 )
 
 data class Source(
-    val name: String?,
-    val slug: String?,
+    val name: String,
+    val slug: ProviderSlug,
     val logo: String?
 )
 

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Workout.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Workout.kt
@@ -52,7 +52,7 @@ data class Workout(
     val map: MapData?,
     @Json(name = "provider_id")
     val providerId: String?,
-    val source: Source?,
+    val source: Source,
 )
 
 data class Sport(

--- a/VitalClient/src/main/java/io/tryvital/client/userConnectedSources.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/userConnectedSources.kt
@@ -1,0 +1,23 @@
+package io.tryvital.client
+
+import io.tryvital.client.services.data.ManualProviderRequest
+import io.tryvital.client.services.data.ManualProviderSlug
+import retrofit2.HttpException
+
+// TODO: VIT-2924 Move userId management to VitalClient
+suspend fun VitalClient.createConnectedSource(provider: ManualProviderSlug, userId: String) {
+    try {
+        linkService.manualProvider(
+            provider = provider,
+            request = ManualProviderRequest(userId = userId)
+        )
+    } catch (exception: HttpException) {
+        if (exception.code() == 409) {
+            // A 409 means that there's a already a connected source, so we can fail gracefully.
+            return
+        } else {
+            // Rethrow exception.
+            throw exception
+        }
+    }
+}

--- a/VitalClient/src/test/java/io/tryvital/client/ActivityServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/ActivityServiceTest.kt
@@ -2,6 +2,7 @@ package io.tryvital.client
 
 import io.tryvital.client.dependencies.Dependencies
 import io.tryvital.client.services.ActivityService
+import io.tryvital.client.services.data.ProviderSlug
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
@@ -59,7 +60,11 @@ class ActivityServiceTest {
         assertEquals(1565.0, activity.caloriesTotal)
         assertEquals(1565.0, activity.caloriesActive)
         assertEquals("Fitbit", activity.source.name)
-        assertEquals("fitbit", activity.source.slug)
+        assertEquals(ProviderSlug.Fitbit, activity.source.slug)
+
+        val activity2 = response.activity[1]
+        assertEquals("Health Connect", activity2.source.name)
+        assertEquals(ProviderSlug.HealthConnect, activity2.source.slug)
     }
 
 }
@@ -104,8 +109,8 @@ const val fakeActivityResponse = """{
     "medium": null,
     "high": null,
     "source": {
-    "name": null,
-    "slug": null,
+    "name": "Health Connect",
+    "slug": "health_connect",
     "logo": null
 }
 }

--- a/VitalClient/src/test/java/io/tryvital/client/BodyServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/BodyServiceTest.kt
@@ -2,6 +2,7 @@ package io.tryvital.client
 
 import io.tryvital.client.dependencies.Dependencies
 import io.tryvital.client.services.BodyService
+import io.tryvital.client.services.data.ProviderSlug
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
@@ -59,15 +60,15 @@ class BodyServiceTest {
         assertEquals(0.0, bodyData.fat)
         assertEquals(80.0, bodyData.weight)
         assertEquals("Fitbit", bodyData.source.name)
-        assertEquals("fitbit", bodyData.source.slug)
+        assertEquals(ProviderSlug.Fitbit, bodyData.source.slug)
 
         val bodyData2 = response.body[1]
         assertEquals("id_2", bodyData2.id)
         assertNull(bodyData2.userId)
         assertNull(bodyData2.fat)
         assertNull(bodyData2.weight)
-        assertNull(bodyData2.source.name)
-        assertNull(bodyData2.source.slug)
+        assertEquals("Health Connect", bodyData2.source.name)
+        assertEquals(ProviderSlug.HealthConnect, bodyData2.source.slug)
 
     }
 
@@ -103,8 +104,8 @@ const val fakeBodyResponse = """{
             "weight": null,
             "fat": null,
             "source": {
-                "name": null,
-                "slug": null,
+                "name": "Health Connect",
+                "slug": "health_connect",
                 "logo": null
             }
         }

--- a/VitalClient/src/test/java/io/tryvital/client/ProfileServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/ProfileServiceTest.kt
@@ -2,6 +2,7 @@ package io.tryvital.client
 
 import io.tryvital.client.dependencies.Dependencies
 import io.tryvital.client.services.ProfileService
+import io.tryvital.client.services.data.ProviderSlug
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
@@ -51,7 +52,7 @@ class ProfileServiceTest {
         assertEquals(userId, profile.userId)
         assertEquals(180.0, profile.height)
         assertEquals("Oura", profile.source?.name)
-        assertEquals("oura", profile.source?.slug)
+        assertEquals(ProviderSlug.Oura, profile.source?.slug)
     }
 
     @Test

--- a/VitalClient/src/test/java/io/tryvital/client/SleepServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/SleepServiceTest.kt
@@ -2,6 +2,7 @@ package io.tryvital.client
 
 import io.tryvital.client.dependencies.Dependencies
 import io.tryvital.client.services.SleepService
+import io.tryvital.client.services.data.ProviderSlug
 import io.tryvital.client.services.data.SleepData
 import io.tryvital.client.services.data.SleepStreamResponse
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -53,9 +54,12 @@ class SleepServiceTest {
             server.takeRequest().requestLine
         )
 
-        assertEquals(3, response.sleep.size)
+        assertEquals(2, response.sleep.size)
         val sleep = response.sleep[0]
         checkFirstSleep(sleep)
+
+        assertEquals("Health Connect", response.sleep[1].source.name)
+        assertEquals(ProviderSlug.HealthConnect, response.sleep[1].source.slug)
     }
 
     @Test
@@ -82,6 +86,9 @@ class SleepServiceTest {
         val sleep = response.sleep[0]
         checkFirstSleep(sleep)
         checkFirstSleepStream(sleep.sleepStream!!)
+
+        assertEquals("Health Connect", response.sleep[1].source.name)
+        assertEquals(ProviderSlug.HealthConnect, response.sleep[1].source.slug)
     }
 
     @Test
@@ -109,8 +116,8 @@ class SleepServiceTest {
         assertEquals(21480, sleep.duration)
         assertEquals(80.0, sleep.efficiency)
         assertEquals(17.12, sleep.respiratoryRate)
-        assertEquals("Oura", sleep.source!!.name)
-        assertEquals("oura", sleep.source!!.slug)
+        assertEquals("Oura", sleep.source.name)
+        assertEquals(ProviderSlug.Oura, sleep.source.slug)
     }
 
     private fun checkFirstSleepStream(sleepStream: SleepStreamResponse) {
@@ -184,35 +191,10 @@ const val fakeSleepDataResponse = """{
     "average_hrv": null,
     "respiratory_rate": null,
     "source": {
-    "name": null,
-    "slug": null,
+    "name": "Health Connect",
+    "slug": "health_connect",
     "logo": null
 },
-    "sleep_stream": null
-},
-{
-    "user_id": "user_id_1",
-    "user_key": "user_id_1",
-    "id": "id_2",
-    "date": "2022-07-14T00:00:00+00:00",
-    "bedtime_start": null,
-    "bedtime_stop": null,
-    "timezone_offset": null,
-    "duration": null,
-    "total": null,
-    "awake": null,
-    "light": null,
-    "rem": null,
-    "deep": null,
-    "score": null,
-    "hr_lowest": null,
-    "hr_average": null,
-    "efficiency": null,
-    "latency": null,
-    "temperature_delta": null,
-    "average_hrv": null,
-    "respiratory_rate": null,
-    "source": null,
     "sleep_stream": null
 }
 ]
@@ -316,8 +298,8 @@ const val fakeSleepStreamSeriesResponse = """{
     "average_hrv": null,
     "respiratory_rate": null,
     "source": {
-    "name": null,
-    "slug": null,
+    "name": "Health Connect",
+    "slug": "health_connect",
     "logo": null
 },
     "sleep_stream": {}

--- a/VitalClient/src/test/java/io/tryvital/client/SummaryServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/SummaryServiceTest.kt
@@ -45,7 +45,7 @@ class SummaryServiceTest {
             userId = userId,
             body = SummaryPayload(
                 stage = "dev",
-                provider = "manual",
+                provider = ManualProviderSlug.Manual,
                 startDate = null,
                 endDate = null,
                 timeZoneId = null,
@@ -81,7 +81,7 @@ class SummaryServiceTest {
             userId = userId,
             body = SummaryPayload(
                 stage = "dev",
-                provider = "manual",
+                provider = ManualProviderSlug.Manual,
                 startDate = null,
                 endDate = null,
                 timeZoneId = null,
@@ -109,7 +109,7 @@ class SummaryServiceTest {
             userId = userId,
             body = SummaryPayload(
                 stage = "dev",
-                provider = "manual",
+                provider = ManualProviderSlug.Manual,
                 startDate = null,
                 endDate = null,
                 timeZoneId = null,
@@ -136,7 +136,7 @@ class SummaryServiceTest {
             userId = userId,
             body = SummaryPayload(
                 stage = "dev",
-                provider = "manual",
+                provider = ManualProviderSlug.Manual,
                 startDate = null,
                 endDate = null,
                 timeZoneId = null,
@@ -160,7 +160,7 @@ class SummaryServiceTest {
             userId = userId,
             body = SummaryPayload(
                 stage = "dev",
-                provider = "manual",
+                provider = ManualProviderSlug.Manual,
                 startDate = null,
                 endDate = null,
                 timeZoneId = null,

--- a/VitalClient/src/test/java/io/tryvital/client/WorkoutServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/WorkoutServiceTest.kt
@@ -2,6 +2,7 @@ package io.tryvital.client
 
 import io.tryvital.client.dependencies.Dependencies
 import io.tryvital.client.services.WorkoutService
+import io.tryvital.client.services.data.ProviderSlug
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
@@ -55,8 +56,12 @@ class WorkoutServiceTest {
         assertEquals(5.81152, workout1.averageSpeed)
         assertEquals(43, workout1.sport!!.id)
         assertEquals("Cycling", workout1.sport!!.name)
-        assertEquals("Peloton", workout1.source!!.name)
-        assertEquals("peloton", workout1.source!!.slug)
+        assertEquals("Peloton", workout1.source.name)
+        assertEquals(ProviderSlug.Peloton, workout1.source.slug)
+
+        val workout2 = response.workouts[1]
+        assertEquals("Health Connect", workout2.source.name)
+        assertEquals(ProviderSlug.HealthConnect, workout2.source.slug)
     }
 
     @Test
@@ -181,7 +186,11 @@ const val fakeWorkoutsResponse = """
         "weighted_average_watts": null,
         "map": null,
         "provider_id": null,
-        "source": null
+        "source": {
+        "name": "Health Connect",
+        "slug": "health_connect",
+        "logo": ""
+        }
     }
     ]
 }

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordUploader.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordUploader.kt
@@ -2,7 +2,6 @@ package io.tryvital.vitalhealthconnect.records
 
 import io.tryvital.client.VitalClient
 import io.tryvital.client.services.data.*
-import io.tryvital.vitalhealthconnect.providerId
 import java.util.*
 
 private const val stage = "daily"
@@ -103,7 +102,7 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
             vitalClient.summaryService.addSleeps(
                 userId, SummaryPayload(
                     stage = stage,
-                    provider = providerId,
+                    provider = ManualProviderSlug.HealthConnect,
                     startDate = startDate,
                     endDate = endDate,
                     timeZoneId = timeZoneId,
@@ -123,7 +122,7 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         vitalClient.summaryService.addBody(
             userId, SummaryPayload(
                 stage = stage,
-                provider = providerId,
+                provider = ManualProviderSlug.HealthConnect,
                 startDate = startDate,
                 endDate = endDate,
                 timeZoneId = timeZoneId,
@@ -142,7 +141,7 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         vitalClient.summaryService.addProfile(
             userId, SummaryPayload(
                 stage = stage,
-                provider = providerId,
+                provider = ManualProviderSlug.HealthConnect,
                 startDate = startDate,
                 endDate = endDate,
                 timeZoneId = timeZoneId,
@@ -162,7 +161,7 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
             vitalClient.summaryService.addActivities(
                 userId, SummaryPayload(
                     stage = stage,
-                    provider = providerId,
+                    provider = ManualProviderSlug.HealthConnect,
                     startDate = startDate,
                     endDate = endDate,
                     timeZoneId = timeZoneId,
@@ -183,7 +182,7 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
             vitalClient.summaryService.addWorkouts(
                 userId, SummaryPayload(
                     stage = stage,
-                    provider = providerId,
+                    provider = ManualProviderSlug.HealthConnect,
                     startDate = startDate,
                     endDate = endDate,
                     timeZoneId = timeZoneId,
@@ -204,7 +203,7 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
             vitalClient.vitalsService.sendGlucose(
                 userId, TimeseriesPayload(
                     stage = stage,
-                    provider = providerId,
+                    provider = ManualProviderSlug.HealthConnect,
                     startDate = startDate,
                     endDate = endDate,
                     timeZoneId = timeZoneId,
@@ -225,7 +224,7 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
             vitalClient.vitalsService.sendBloodPressure(
                 userId, TimeseriesPayload(
                     stage = stage,
-                    provider = providerId,
+                    provider = ManualProviderSlug.HealthConnect,
                     startDate = startDate,
                     endDate = endDate,
                     timeZoneId = timeZoneId,
@@ -246,7 +245,7 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
             vitalClient.vitalsService.sendHeartRate(
                 userId, TimeseriesPayload(
                     stage = stage,
-                    provider = providerId,
+                    provider = ManualProviderSlug.HealthConnect,
                     startDate = startDate,
                     endDate = endDate,
                     timeZoneId = timeZoneId,
@@ -267,7 +266,7 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
             vitalClient.vitalsService.sendHeartRateVariability(
                 userId, TimeseriesPayload(
                     stage = stage,
-                    provider = providerId,
+                    provider = ManualProviderSlug.HealthConnect,
                     startDate = startDate,
                     endDate = endDate,
                     timeZoneId = timeZoneId,
@@ -288,7 +287,7 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
             vitalClient.vitalsService.sendWater(
                 userId, TimeseriesPayload(
                     stage = stage,
-                    provider = providerId,
+                    provider = ManualProviderSlug.HealthConnect,
                     startDate = startDate,
                     endDate = endDate,
                     timeZoneId = timeZoneId,

--- a/app/src/main/java/io/tryvital/sample/ui/healthconnect/HealthConnectViewModel.kt
+++ b/app/src/main/java/io/tryvital/sample/ui/healthconnect/HealthConnectViewModel.kt
@@ -75,12 +75,6 @@ class HealthConnectViewModel(
         }
     }
 
-    fun linkProvider() {
-        viewModelScope.launch {
-            vitalHealthConnectManager.linkUserHealthConnectProvider("vitalexample://callback")
-        }
-    }
-
     fun sync() {
         viewModelScope.launch {
             vitalHealthConnectManager.apply {

--- a/app/src/main/java/io/tryvital/sample/ui/healthconnect/ReadDataCard.kt
+++ b/app/src/main/java/io/tryvital/sample/ui/healthconnect/ReadDataCard.kt
@@ -39,26 +39,6 @@ fun ReadDataCard(
                 Row {
                     Button(
                         onClick = {
-                            viewModel.linkProvider()
-                        },
-                        contentPadding = PaddingValues(
-                            start = 20.dp,
-                            top = 12.dp,
-                            end = 20.dp,
-                            bottom = 12.dp
-                        )
-                    ) {
-                        Icon(
-                            Icons.Outlined.Healing,
-                            contentDescription = null,
-                            modifier = Modifier.size(ButtonDefaults.IconSize)
-                        )
-                        Spacer(Modifier.size(ButtonDefaults.IconSpacing))
-                        Text("Link Provider")
-                    }
-                    Spacer(modifier = Modifier.weight(1f))
-                    Button(
-                        onClick = {
                             viewModel.sync()
                         },
                         contentPadding = PaddingValues(


### PR DESCRIPTION
* Introduce `ProviderSlug` and `ManualProviderSlug` enums.

* Update request method/models to use these enums.

* Move the connected source creation logic from VitalHealthConnect to VitalClient as `VitalClient.createConnectedSource`. The implementation is currently very basic (always calling the API). Work from VIT-2924 and VIT-2944 will eventually bring parity with iOS SDK.

* Updated all the tests and fixtures impacted by the changes.
