### PR TITLE
[VIT-2993] Refactor sync work management

### DIFF
--- a/VitalHealthConnect/build.gradle
+++ b/VitalHealthConnect/build.gradle
@@ -47,6 +47,8 @@ dependencies {
     implementation project(':VitalClient')
 
     implementation "androidx.health.connect:connect-client:$health_connect"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_livedata_ktx"
+
     implementation "androidx.startup:startup-runtime:$startup_runtime"
     implementation "androidx.security:security-crypto:$security_crypto"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinx_coroutines"

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
         activity_compose = '1.6.1'
         lifecycle_runtime = '2.5.1'
         lifecycle_viewmodel_compose = '2.5.1'
+        lifecycle_livedata_ktx = '2.6.1'
         browser = '1.4.0'
         retrofit = '2.9.0'
         retrofit2_kotlin_coroutines_adapter = '0.9.2'


### PR DESCRIPTION
I didn't fully understand how the sync work was managed when doing #29.

Now upon reviewing the whole process from the entry point `syncData()`, I noticed my assumption of the SyncData workers being permanently running in background like a daemon was incorrect (fooled by the use of `observeForever`).

Instead, these are more like one-off workers, that are enqueued every time we need to sync. So this PR aims at rectifying them.


1. The async `syncData()` method now waits until the whole sync process is completed for all the specified resources before  it returns.

    * Same as the iOS SDK.
    * Caller can cancel the sync. Alternatively, `close()`ing the VitalHealthConnectManager would also cancel the sync.

2. `syncData()` is now serialized; only one will be executed at any given time. Other concurrent attempts would be suspended and then executed one by one.

    * This is not currently the case — every call will try to spawn new workers to replace the running one.
    * This is achieved by the use of kotlin coroutines `Semaphore`, an async-safe locking primitive.

3. (2) + (3) combined is a precaution against spam calls that would otherwise trigger Health Connect rate limit.

     * Need to look further into this to see if we can/need to add delay & retry transparently.

4. Manage the Android Worker observation as Kotlin Flow, so we don't need to manage the observer registrations & removal ourselves.

    * Google provides an official extension package for `LiveData<T>` -> `Flow<T>` bridge.