### PR TITLE
[VIT-2998] Sync Statuses are dropped instead of buffered for slow subscribers.

### DIFF
--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
@@ -23,6 +23,7 @@ import io.tryvital.vitalhealthconnect.model.processedresource.ProcessedResourceD
 import io.tryvital.vitalhealthconnect.records.*
 import io.tryvital.vitalhealthconnect.workers.*
 import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.sync.Semaphore
 import java.time.Instant
@@ -92,7 +93,9 @@ class VitalHealthConnectManager private constructor(
 
     private val vitalLogger = vitalClient.vitalLogger
 
-    private val _status = MutableSharedFlow<SyncStatus>(replay = 1)
+    // Unlimited buffering for slow subscribers.
+    // https://github.com/Kotlin/kotlinx.coroutines/issues/2034#issuecomment-630381961
+    private val _status = MutableSharedFlow<SyncStatus>(replay = 1, extraBufferCapacity = Int.MAX_VALUE)
     val status: SharedFlow<SyncStatus> = _status
 
     private val currentSyncCall = Semaphore(1, 0)


### PR DESCRIPTION
When testing RN, I noticed that some sync statuses were missing.

Turns out that we are using `tryEmit(_:)`.

`tryEmit(_:)` attempts to immediately send the value, but fails gracefully if the subscribers are not ready. This is suitable when we need backpressure from API consumers, but not for SDK sync status.

To address this, we configure the SDK sync status `SharedFlow` to have unlimited buffering. This allows `tryEmit(_:)` to always succeed (like Swift `AsyncStream` with unlimited buffering), since it can always write into the buffer, irrespective to the readiness of subscribers.

The buffer is designed to gradually shrunk as the subscribers drain from it (IIRC linked list underneath). So memory leak is not a concern.

https://github.com/tryVital/vital-android/blob/3512725ed4e5846e7630714120b18a7666ac6a8f/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt#L282-L292