### PR TITLE
[VIT-3030] Convenience to open Health Connect or Play Store if uninstalled

### DIFF
--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthAutoStarter.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthAutoStarter.kt
@@ -6,6 +6,7 @@ import androidx.startup.Initializer
 import io.tryvital.client.Environment
 import io.tryvital.client.Region
 import io.tryvital.client.utils.VitalLogger
+import io.tryvital.vitalhealthconnect.model.HealthConnectAvailability
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -47,6 +48,11 @@ class VitalHealthAutoStarter(private val context: Context) {
     }
 
     private fun startSync() {
+        if (VitalHealthConnectManager.isAvailable(context) != HealthConnectAvailability.Installed) {
+            vitalLogger.logI("Health Connect is unavailable; will not start sync on startup")
+            return
+        }
+
         try {
             if (sharedPreferences.contains(UnSecurePrefKeys.syncOnAppStartKey)) {
                 val region = encryptedSharedPreferences.getString(SecurePrefKeys.regionKey, null)

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
@@ -2,10 +2,13 @@ package io.tryvital.vitalhealthconnect
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.Intent
 import android.content.SharedPreferences
+import android.net.Uri
 import android.os.Build
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.HealthConnectClient.Companion.ACTION_HEALTH_CONNECT_SETTINGS
 import androidx.health.connect.client.permission.HealthPermission
 import androidx.health.connect.client.records.*
 import androidx.health.connect.client.units.BloodGlucose
@@ -583,6 +586,23 @@ class VitalHealthConnectManager private constructor(
                 HealthConnectClient.SDK_AVAILABLE -> HealthConnectAvailability.Installed
                 HealthConnectClient.SDK_UNAVAILABLE_PROVIDER_UPDATE_REQUIRED -> HealthConnectAvailability.NotInstalled
                 else -> HealthConnectAvailability.NotSupportedSDK
+            }
+        }
+
+        @Suppress("unused")
+        fun openHealthConnect(context: Context) {
+            when (isAvailable(context)) {
+                HealthConnectAvailability.NotSupportedSDK -> {}
+                HealthConnectAvailability.NotInstalled -> {
+                    val intent = Intent(Intent.ACTION_VIEW).apply {
+                        data = Uri.parse("https://play.google.com/store/apps/details?id=com.google.android.apps.healthdata")
+                        setPackage("com.android.vending")
+                    }
+                    context.startActivity(intent)
+                }
+                HealthConnectAvailability.Installed -> {
+                    context.startActivity(Intent(ACTION_HEALTH_CONNECT_SETTINGS))
+                }
             }
         }
 

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
@@ -138,6 +138,10 @@ class VitalHealthConnectManager private constructor(
     }
 
     suspend fun checkAndUpdatePermissions() {
+        if (isAvailable(context) != HealthConnectAvailability.Installed) {
+            return
+        }
+
         val currentGrants = getGrantedPermissions(context)
 
         val readResourcesByStatus = VitalResource.values()
@@ -220,7 +224,7 @@ class VitalHealthConnectManager private constructor(
             commit()
         }
 
-        if (hasConfigSet()) {
+        if (hasConfigSet() && isAvailable(context) == HealthConnectAvailability.Installed) {
             vitalLogger.logI("User ID set, starting sync")
             syncData(healthResources)
         }
@@ -246,7 +250,7 @@ class VitalHealthConnectManager private constructor(
             .putInt(UnSecurePrefKeys.numberOfDaysToBackFillKey, numberOfDaysToBackFill)
             .commit()
 
-        if (hasUserId()) {
+        if (hasUserId() && isAvailable(context) == HealthConnectAvailability.Installed) {
             vitalLogger.logI("Configuration set, starting sync")
             syncData(healthResources)
         }

--- a/app/src/main/java/io/tryvital/sample/ui/healthconnect/HealthConnectCard.kt
+++ b/app/src/main/java/io/tryvital/sample/ui/healthconnect/HealthConnectCard.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.HealthAndSafety
 import androidx.compose.material.icons.outlined.InstallMobile
+import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
@@ -58,6 +59,7 @@ fun PermissionInfo(
     permissionsMissing: List<VitalResource>,
     viewModel: HealthConnectViewModel
 ) {
+    val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     val permissionsLauncher =
         rememberLauncherForActivityResult(viewModel.createPermissionRequestContract()) { outcomeAsync ->
@@ -106,17 +108,33 @@ fun PermissionInfo(
         }
 
         Spacer(Modifier.height(8.dp))
-        Button(
-            onClick = { permissionsLauncher.launch(Unit) },
-            contentPadding = ButtonDefaults.TextButtonContentPadding
-        ) {
-            Icon(
-                Icons.Outlined.HealthAndSafety,
-                contentDescription = null,
-                modifier = Modifier.size(ButtonDefaults.IconSize)
-            )
-            Spacer(Modifier.size(ButtonDefaults.IconSpacing))
-            Text("Request")
+
+        Row(Modifier.fillMaxWidth()) {
+            Button(
+                onClick = { permissionsLauncher.launch(Unit) },
+                contentPadding = ButtonDefaults.TextButtonContentPadding
+            ) {
+                Icon(
+                    Icons.Outlined.HealthAndSafety,
+                    contentDescription = null,
+                    modifier = Modifier.size(ButtonDefaults.IconSize)
+                )
+                Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+                Text("Request")
+            }
+
+            Button(
+                onClick = { viewModel.openHealthConnect(context) },
+                contentPadding = ButtonDefaults.TextButtonContentPadding
+            ) {
+                Icon(
+                    Icons.Outlined.Link,
+                    contentDescription = null,
+                    modifier = Modifier.size(ButtonDefaults.IconSize)
+                )
+                Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+                Text("Open Health Connect")
+            }
         }
     }
 }

--- a/app/src/main/java/io/tryvital/sample/ui/healthconnect/HealthConnectViewModel.kt
+++ b/app/src/main/java/io/tryvital/sample/ui/healthconnect/HealthConnectViewModel.kt
@@ -51,6 +51,8 @@ class HealthConnectViewModel(
         }
     }
 
+    fun openHealthConnect(context: Context) = VitalHealthConnectManager.openHealthConnect(context)
+
     fun checkPermissions() {
         viewModelScope.launch {
             val state = viewModelState.value


### PR DESCRIPTION
A convenient way to either open Health Connect for permission settings, or open Play Store if Health Connect is not yet been installed.

Also make sure VitalHealthConnectManager proactively bails itself out whenever it finds the HC SDK being unavailable. 

(iOS party ~= `x-apple-health://`...)