### PR TITLE
[VIT-3126] RecordProcessor should not need datetime input

### DIFF
--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
@@ -303,8 +303,6 @@ class VitalHealthConnectManager private constructor(
 
         suspend fun readActivities(): ProcessedResourceData {
             val activities = recordProcessor.processActivitiesFromRecords(
-                startDate,
-                endDate,
                 TimeZone.getDefault(),
                 currentDevice,
                 recordReader.readActiveEnergyBurned(startDate, endDate),
@@ -322,24 +320,18 @@ class VitalHealthConnectManager private constructor(
             VitalResource.BasalEnergyBurned -> readActivities()
             VitalResource.BloodPressure -> ProcessedResourceData.TimeSeries(
                 recordProcessor.processBloodPressureFromRecords(
-                    startDate,
-                    endDate,
                     currentDevice,
                     recordReader.readBloodPressure(startDate, endDate)
                 )
             )
             VitalResource.Glucose -> ProcessedResourceData.TimeSeries(
                 recordProcessor.processGlucoseFromRecords(
-                    startDate,
-                    endDate,
                     currentDevice,
                     recordReader.readBloodGlucose(startDate, endDate)
                 )
             )
             VitalResource.HeartRate -> ProcessedResourceData.TimeSeries(
                 recordProcessor.processHeartRateFromRecords(
-                    startDate,
-                    endDate,
                     currentDevice,
                     recordReader.readHeartRate(startDate, endDate)
                 )
@@ -347,16 +339,12 @@ class VitalHealthConnectManager private constructor(
             VitalResource.Steps -> readActivities()
             VitalResource.Water -> ProcessedResourceData.TimeSeries(
                 recordProcessor.processWaterFromRecords(
-                    startDate,
-                    endDate,
                     currentDevice,
                     recordReader.readHydration(startDate, endDate)
                 )
             )
             VitalResource.Body -> ProcessedResourceData.Summary(
                 recordProcessor.processBodyFromRecords(
-                    startDate,
-                    endDate,
                     currentDevice,
                     recordReader.readWeights(startDate, endDate),
                     recordReader.readBodyFat(startDate, endDate)
@@ -364,15 +352,11 @@ class VitalHealthConnectManager private constructor(
             )
             VitalResource.Profile -> ProcessedResourceData.Summary(
                 recordProcessor.processProfileFromRecords(
-                    startDate,
-                    endDate,
                     recordReader.readHeights(startDate, endDate)
                 )
             )
             VitalResource.Sleep -> ProcessedResourceData.Summary(
                 recordProcessor.processSleepFromRecords(
-                    startDate,
-                    endDate,
                     currentDevice,
                     recordReader.readSleepSession(startDate, endDate),
                     recordReader.readSleepStages(startDate, endDate),
@@ -381,16 +365,12 @@ class VitalHealthConnectManager private constructor(
             VitalResource.Activity -> readActivities()
             VitalResource.Workout -> ProcessedResourceData.Summary(
                 recordProcessor.processWorkoutsFromRecords(
-                    startDate,
-                    endDate,
                     currentDevice,
                     recordReader.readExerciseSessions(startDate, endDate)
                 )
             )
             VitalResource.HeartRateVariability -> ProcessedResourceData.TimeSeries(
                 recordProcessor.processHeartRateVariabilityRmssFromRecords(
-                    startDate,
-                    endDate,
                     currentDevice,
                     recordReader.readHeartRateVariabilityRmssd(startDate, endDate)
                 )

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordProcessor.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordProcessor.kt
@@ -20,74 +20,54 @@ import kotlin.math.roundToInt
 interface RecordProcessor {
 
     suspend fun processBloodPressureFromRecords(
-        startDate: Instant,
-        endDate: Instant,
         currentDevice: String,
         readBloodPressure: List<BloodPressureRecord>
     ): TimeSeriesData.BloodPressure
 
     suspend fun processGlucoseFromRecords(
-        startDate: Instant,
-        endDate: Instant,
         currentDevice: String,
         readBloodGlucose: List<BloodGlucoseRecord>
     ): TimeSeriesData.Glucose
 
     suspend fun processHeartRateFromRecords(
-        startDate: Instant,
-        endDate: Instant,
         currentDevice: String,
         heartRateRecords: List<HeartRateRecord>
     ): TimeSeriesData.HeartRate
 
 
     fun processHeartRateVariabilityRmssFromRecords(
-        startDate: Instant,
-        endDate: Instant,
         currentDevice: String,
         heartRateRecords: List<HeartRateVariabilityRmssdRecord>
     ): TimeSeriesData.HeartRateVariabilityRmssd
 
     fun processWaterFromRecords(
-        startDate: Instant,
-        endDate: Instant,
         currentDevice: String,
         readHydration: List<HydrationRecord>
     ): TimeSeriesData.Water
 
     suspend fun processBodyFromRecords(
-        startTime: Instant,
-        endTime: Instant,
         fallbackDeviceModel: String,
         weightRecords: List<WeightRecord>,
         bodyFatRecords: List<BodyFatRecord>,
     ): SummaryData.Body
 
     suspend fun processProfileFromRecords(
-        startTime: Instant,
-        endTime: Instant,
         heightRecords: List<HeightRecord>,
     ): SummaryData.Profile
 
 
     suspend fun processWorkoutsFromRecords(
-        startTime: Instant,
-        endTime: Instant,
         fallbackDeviceModel: String,
         exerciseRecords: List<ExerciseSessionRecord>
     ): SummaryData.Workouts
 
     suspend fun processSleepFromRecords(
-        startTime: Instant,
-        endTime: Instant,
         fallbackDeviceModel: String,
         sleepSessionRecords: List<SleepSessionRecord>,
         readSleepStages: List<SleepStageRecord>
     ): SummaryData.Sleeps
 
     suspend fun processActivitiesFromRecords(
-        startTime: Instant,
-        endTime: Instant,
         timeZone: TimeZone,
         currentDevice: String,
         activeEnergyBurned: List<ActiveCaloriesBurnedRecord>,
@@ -105,8 +85,6 @@ internal class HealthConnectRecordProcessor(
 ) : RecordProcessor {
 
     override suspend fun processBloodPressureFromRecords(
-        startDate: Instant,
-        endDate: Instant,
         currentDevice: String,
         readBloodPressure: List<BloodPressureRecord>
     ): TimeSeriesData.BloodPressure {
@@ -134,8 +112,6 @@ internal class HealthConnectRecordProcessor(
     }
 
     override suspend fun processGlucoseFromRecords(
-        startDate: Instant,
-        endDate: Instant,
         currentDevice: String,
         readBloodGlucose: List<BloodGlucoseRecord>
     ): TimeSeriesData.Glucose {
@@ -152,8 +128,6 @@ internal class HealthConnectRecordProcessor(
     }
 
     override suspend fun processHeartRateFromRecords(
-        startDate: Instant,
-        endDate: Instant,
         currentDevice: String,
         heartRateRecords: List<HeartRateRecord>
     ): TimeSeriesData.HeartRate {
@@ -163,8 +137,6 @@ internal class HealthConnectRecordProcessor(
     }
 
     override fun processHeartRateVariabilityRmssFromRecords(
-        startDate: Instant,
-        endDate: Instant,
         currentDevice: String,
         heartRateRecords: List<HeartRateVariabilityRmssdRecord>
     ): TimeSeriesData.HeartRateVariabilityRmssd {
@@ -183,8 +155,6 @@ internal class HealthConnectRecordProcessor(
 
 
     override fun processWaterFromRecords(
-        startDate: Instant,
-        endDate: Instant,
         currentDevice: String,
         readHydration: List<HydrationRecord>
     ): TimeSeriesData.Water {
@@ -202,8 +172,6 @@ internal class HealthConnectRecordProcessor(
     }
 
     override suspend fun processWorkoutsFromRecords(
-        startTime: Instant,
-        endTime: Instant,
         fallbackDeviceModel: String,
         exerciseRecords: List<ExerciseSessionRecord>
     ): SummaryData.Workouts {
@@ -239,8 +207,6 @@ internal class HealthConnectRecordProcessor(
     }
 
     override suspend fun processProfileFromRecords(
-        startTime: Instant,
-        endTime: Instant,
         heightRecords: List<HeightRecord>,
     ) =
         SummaryData.Profile(
@@ -251,8 +217,6 @@ internal class HealthConnectRecordProcessor(
         )
 
     override suspend fun processBodyFromRecords(
-        startTime: Instant,
-        endTime: Instant,
         fallbackDeviceModel: String,
         weightRecords: List<WeightRecord>,
         bodyFatRecords: List<BodyFatRecord>
@@ -278,8 +242,6 @@ internal class HealthConnectRecordProcessor(
     )
 
     override suspend fun processSleepFromRecords(
-        startTime: Instant,
-        endTime: Instant,
         fallbackDeviceModel: String,
         sleepSessionRecords: List<SleepSessionRecord>,
         readSleepStages: List<SleepStageRecord>
@@ -408,8 +370,6 @@ internal class HealthConnectRecordProcessor(
     }
 
     override suspend fun processActivitiesFromRecords(
-        startTime: Instant,
-        endTime: Instant,
         timeZone: TimeZone,
         currentDevice: String,
         activeEnergyBurned: List<ActiveCaloriesBurnedRecord>,
@@ -420,25 +380,8 @@ internal class HealthConnectRecordProcessor(
         vo2Max: List<Vo2MaxRecord>
     ): SummaryData.Activities = coroutineScope {
         val zoneId = timeZone.toZoneId()
-        val startDate = LocalDateTime.ofInstant(startTime, zoneId).toLocalDate()
-        val endDate = LocalDateTime.ofInstant(endTime, zoneId).toLocalDate()
-        assert(startDate <= endDate)
 
-        // Inclusive-exclusive
-        val numberOfDays = ChronoUnit.DAYS.between(startDate, endDate.plusDays(1)).toInt()
-
-        val summaryAggregators = Array(numberOfDays) { offset ->
-            async {
-                val date = startDate.plusDays(offset.toLong())
-                val summary = recordAggregator.aggregateActivityDaySummary(
-                    date = startDate.plusDays(offset.toLong()),
-                    timeZone = timeZone
-                )
-                return@async date to summary.toDatedPayload(date)
-            }
-        }
-
-        val activeEnergyBurnedByDate = quantitySamplesByDate(activeEnergyBurned, zoneId, { it.startTime }) {
+        val activeEnergyBurned = quantitySamplesByDate(activeEnergyBurned, zoneId, { it.startTime }) {
             HCQuantitySample(
                 value = it.energy.inKilocalories,
                 unit = SampleType.ActiveCaloriesBurned.unit,
@@ -447,7 +390,7 @@ internal class HealthConnectRecordProcessor(
                 metadata = it.metadata,
             ).toQuantitySample(currentDevice)
         }
-        val basalMetabolicRateByDate = quantitySamplesByDate(basalMetabolicRate, zoneId, { it.time }) {
+        val basalMetabolicRate = quantitySamplesByDate(basalMetabolicRate, zoneId, { it.time }) {
             HCQuantitySample(
                 value = it.basalMetabolicRate.inKilocaloriesPerDay,
                 unit = SampleType.BasalMetabolicRate.unit,
@@ -456,7 +399,7 @@ internal class HealthConnectRecordProcessor(
                 metadata = it.metadata,
             ).toQuantitySample(currentDevice)
         }
-        val distanceByDate = quantitySamplesByDate(distance, zoneId, { it.startTime }) {
+        val distance = quantitySamplesByDate(distance, zoneId, { it.startTime }) {
             HCQuantitySample(
                 value = it.distance.inMeters,
                 unit = SampleType.Distance.unit,
@@ -465,7 +408,7 @@ internal class HealthConnectRecordProcessor(
                 metadata = it.metadata,
             ).toQuantitySample(currentDevice)
         }
-        val floorsClimbedByDate = quantitySamplesByDate(floorsClimbed, zoneId, { it.startTime }) {
+        val floorsClimbed = quantitySamplesByDate(floorsClimbed, zoneId, { it.startTime }) {
             HCQuantitySample(
                 value = it.floors,
                 unit = SampleType.FloorsClimbed.unit,
@@ -474,7 +417,7 @@ internal class HealthConnectRecordProcessor(
                 metadata = it.metadata,
             ).toQuantitySample(currentDevice)
         }
-        val stepsByDate = quantitySamplesByDate(steps, zoneId, { it.startTime }) {
+        val steps = quantitySamplesByDate(steps, zoneId, { it.startTime }) {
             HCQuantitySample(
                 value = it.count.toDouble(),
                 unit = SampleType.Steps.unit,
@@ -484,7 +427,7 @@ internal class HealthConnectRecordProcessor(
             ).toQuantitySample(currentDevice)
 
         }
-        val vo2MaxByDate = quantitySamplesByDate(vo2Max, zoneId, { it.time }) {
+        val vo2Max = quantitySamplesByDate(vo2Max, zoneId, { it.time }) {
             HCQuantitySample(
                 value = it.vo2MillilitersPerMinuteKilogram,
                 unit = SampleType.Vo2Max.unit,
@@ -494,22 +437,60 @@ internal class HealthConnectRecordProcessor(
             ).toQuantitySample(currentDevice)
         }
 
-        val daySummariesByDate = awaitAll(*summaryAggregators).toMap()
+        val startTime = listOfNotNull(
+            activeEnergyBurned.minTime,
+            basalMetabolicRate.minTime,
+            floorsClimbed.minTime,
+            distance.minTime,
+            steps.minTime,
+            vo2Max.minTime
+        ).minOrNull()
+        val endTime = listOfNotNull(
+            activeEnergyBurned.maxTime,
+            basalMetabolicRate.maxTime,
+            floorsClimbed.maxTime,
+            distance.maxTime,
+            steps.maxTime,
+            vo2Max.maxTime
+        ).maxOrNull()
 
-        val activities = (0 until numberOfDays).map { offset ->
-            val date = startDate.plusDays(offset.toLong())
-            Activity(
-                daySummary = daySummariesByDate[date],
-                activeEnergyBurned = activeEnergyBurnedByDate[date] ?: emptyList(),
-                basalEnergyBurned = basalMetabolicRateByDate[date] ?: emptyList(),
-                distanceWalkingRunning = distanceByDate[date] ?: emptyList(),
-                floorsClimbed = floorsClimbedByDate[date] ?: emptyList(),
-                steps = stepsByDate[date] ?: emptyList(),
-                vo2Max = vo2MaxByDate[date] ?: emptyList(),
-            )
+        if (startTime != null && endTime != null) {
+            val startDate = LocalDateTime.ofInstant(startTime, zoneId).toLocalDate()
+            val endDate = LocalDateTime.ofInstant(endTime, zoneId).toLocalDate()
+            assert(startDate <= endDate)
+
+            // Inclusive-exclusive
+            val numberOfDays = ChronoUnit.DAYS.between(startDate, endDate.plusDays(1)).toInt()
+
+            val summaryAggregators = Array(numberOfDays) { offset ->
+                async {
+                    val date = startDate.plusDays(offset.toLong())
+                    val summary = recordAggregator.aggregateActivityDaySummary(
+                        date = startDate.plusDays(offset.toLong()),
+                        timeZone = timeZone
+                    )
+                    return@async date to summary.toDatedPayload(date)
+                }
+            }
+            val daySummariesByDate = awaitAll(*summaryAggregators).toMap()
+
+            val activities = (0 until numberOfDays).map { offset ->
+                val date = startDate.plusDays(offset.toLong())
+                Activity(
+                    daySummary = daySummariesByDate[date],
+                    activeEnergyBurned = activeEnergyBurned.samplesByDate[date] ?: emptyList(),
+                    basalEnergyBurned = basalMetabolicRate.samplesByDate[date] ?: emptyList(),
+                    distanceWalkingRunning = distance.samplesByDate[date] ?: emptyList(),
+                    floorsClimbed = floorsClimbed.samplesByDate[date] ?: emptyList(),
+                    steps = steps.samplesByDate[date] ?: emptyList(),
+                    vo2Max = vo2Max.samplesByDate[date] ?: emptyList(),
+                )
+            }
+
+            SummaryData.Activities(activities = activities)
+        } else {
+            SummaryData.Activities(activities = emptyList())
         }
-
-        SummaryData.Activities(activities = activities)
     }
 
 
@@ -604,14 +585,29 @@ private fun List<SleepSessionRecord>.filterForAcceptedSleepDataSources(): List<S
     }
 }
 
+data class GroupedSamples(
+    val samplesByDate: Map<LocalDate, List<QuantitySample>>,
+    val minTime: Instant?,
+    val maxTime: Instant?,
+)
+
 inline fun <R: Record> quantitySamplesByDate(
     records: Iterable<R>,
     zoneId: ZoneId,
     timeSelector: (R) -> Instant,
     transform: (R) -> QuantitySample
-): Map<LocalDate, List<QuantitySample>> {
-    return records.groupBy(
+): GroupedSamples {
+    val samplesByDate = records.groupBy(
         keySelector = { timeSelector(it).atZone(zoneId).toLocalDate() },
         valueTransform = transform
+    )
+    return GroupedSamples(
+        samplesByDate,
+        minTime = samplesByDate.keys.minOrNull()?.let { date ->
+            samplesByDate[date]?.minOf { it.startDate.toInstant() }
+        },
+        maxTime = samplesByDate.keys.maxOrNull()?.let { date ->
+            samplesByDate[date]?.maxOf { it.endDate.toInstant() }
+        },
     )
 }

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/UploadAllDataWorker.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/UploadAllDataWorker.kt
@@ -153,7 +153,7 @@ class UploadAllDataWorker(appContext: Context, workerParams: WorkerParameters) :
     ) {
         reportStatus(VitalResource.Water, syncing)
         val waters = recordProcessor.processWaterFromRecords(
-            startTime, endTime, currentDevice, recordReader.readHydration(startTime, endTime)
+            currentDevice, recordReader.readHydration(startTime, endTime)
         )
 
         if (waters.samples.isEmpty()) {
@@ -179,7 +179,7 @@ class UploadAllDataWorker(appContext: Context, workerParams: WorkerParameters) :
     ) {
         reportStatus(VitalResource.HeartRate, syncing)
         val heartRatePayloads = recordProcessor.processHeartRateFromRecords(
-            startTime, endTime, currentDevice, recordReader.readHeartRate(startTime, endTime)
+            currentDevice, recordReader.readHeartRate(startTime, endTime)
         )
         if (heartRatePayloads.samples.isEmpty()) {
             reportStatus(VitalResource.HeartRate, nothingToSync)
@@ -204,8 +204,6 @@ class UploadAllDataWorker(appContext: Context, workerParams: WorkerParameters) :
     ) {
         reportStatus(VitalResource.HeartRateVariability, syncing)
         val heartRatePayloads = recordProcessor.processHeartRateVariabilityRmssFromRecords(
-            startTime,
-            endTime,
             currentDevice,
             recordReader.readHeartRateVariabilityRmssd(startTime, endTime)
         )
@@ -232,7 +230,7 @@ class UploadAllDataWorker(appContext: Context, workerParams: WorkerParameters) :
     ) {
         reportStatus(VitalResource.BloodPressure, syncing)
         val bloodPressurePayloads = recordProcessor.processBloodPressureFromRecords(
-            startTime, endTime, currentDevice, recordReader.readBloodPressure(
+            currentDevice, recordReader.readBloodPressure(
                 startTime, endTime,
             )
         )
@@ -259,7 +257,7 @@ class UploadAllDataWorker(appContext: Context, workerParams: WorkerParameters) :
     ) {
         reportStatus(VitalResource.Glucose, syncing)
         val glucosePayloads = recordProcessor.processGlucoseFromRecords(
-            startTime, endTime, currentDevice, recordReader.readBloodGlucose(startTime, endTime)
+            currentDevice, recordReader.readBloodGlucose(startTime, endTime)
         )
         if (glucosePayloads.samples.isEmpty()) {
             reportStatus(VitalResource.Glucose, nothingToSync)
@@ -286,8 +284,6 @@ class UploadAllDataWorker(appContext: Context, workerParams: WorkerParameters) :
         reportStatus(VitalResource.Sleep, syncing)
         val sleepPayloads =
             recordProcessor.processSleepFromRecords(
-                startTime,
-                endTime,
                 currentDevice,
                 recordReader.readSleepSession(startTime, endTime),
                 recordReader.readSleepStages(startTime, endTime)
@@ -317,8 +313,6 @@ class UploadAllDataWorker(appContext: Context, workerParams: WorkerParameters) :
         reportStatus(VitalResource.Body, syncing)
         val bodyPayload =
             recordProcessor.processBodyFromRecords(
-                startTime,
-                endTime,
                 currentDevice,
                 recordReader.readWeights(startTime, endTime),
                 recordReader.readBodyFat(startTime, endTime),
@@ -343,8 +337,6 @@ class UploadAllDataWorker(appContext: Context, workerParams: WorkerParameters) :
     ) {
         reportStatus(VitalResource.Profile, syncing)
         val profilePayload = recordProcessor.processProfileFromRecords(
-            startTime,
-            endTime,
             recordReader.readHeights(startTime, endTime)
         )
         recordUploader.uploadProfile(
@@ -368,8 +360,6 @@ class UploadAllDataWorker(appContext: Context, workerParams: WorkerParameters) :
     ) {
         reportStatus(VitalResource.Activity, syncing)
         val activityPayloads = recordProcessor.processActivitiesFromRecords(
-            startTime,
-            endTime,
             TimeZone.getDefault(),
             currentDevice,
             recordReader.readActiveEnergyBurned(startTime, endTime),
@@ -404,7 +394,7 @@ class UploadAllDataWorker(appContext: Context, workerParams: WorkerParameters) :
     ) {
         reportStatus(VitalResource.Workout, syncing)
         val workoutPayloads = recordProcessor.processWorkoutsFromRecords(
-            startTime, endTime, currentDevice, recordReader.readExerciseSessions(startTime, endTime)
+            currentDevice, recordReader.readExerciseSessions(startTime, endTime)
         )
         if (workoutPayloads.samples.isEmpty()) {
             reportStatus(VitalResource.Workout, nothingToSync)

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/UploadChangesWorker.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/UploadChangesWorker.kt
@@ -223,7 +223,7 @@ class UploadChangesWorker(appContext: Context, workerParams: WorkerParameters) :
                 bloodPressureEndTime.toDate(),
                 timeZoneId,
                 recordProcessor.processBloodPressureFromRecords(
-                    bloodPressureStartTime, bloodPressureEndTime, currentDevice, bloodPressure
+                    currentDevice, bloodPressure
                 ).samples.map { it.toBloodPressurePayload() })
 
             reportStatus(VitalResource.BloodPressure, synced)
@@ -246,7 +246,7 @@ class UploadChangesWorker(appContext: Context, workerParams: WorkerParameters) :
                 waterEndTime.toDate(),
                 timeZoneId,
                 recordProcessor.processWaterFromRecords(
-                    waterStartTime, waterEndTime, currentDevice, water
+                    currentDevice, water
                 ).samples.map { it.toQuantitySamplePayload() })
 
             reportStatus(VitalResource.Water, synced)
@@ -268,7 +268,7 @@ class UploadChangesWorker(appContext: Context, workerParams: WorkerParameters) :
                 heartRateEndTime.toDate(),
                 timeZoneId,
                 recordProcessor.processHeartRateFromRecords(
-                    heartRateStartTime, heartRateEndTime, currentDevice, heartRate
+                    currentDevice, heartRate
                 ).samples.map { it.toQuantitySamplePayload() })
 
             reportStatus(VitalResource.HeartRate, synced)
@@ -293,7 +293,7 @@ class UploadChangesWorker(appContext: Context, workerParams: WorkerParameters) :
                 heartRateEndTime.toDate(),
                 timeZoneId,
                 recordProcessor.processHeartRateVariabilityRmssFromRecords(
-                    heartRateStartTime, heartRateEndTime, currentDevice, rmssdRecords
+                    currentDevice, rmssdRecords
                 ).samples.map { it.toQuantitySamplePayload() })
 
             reportStatus(VitalResource.HeartRateVariability, synced)
@@ -318,7 +318,7 @@ class UploadChangesWorker(appContext: Context, workerParams: WorkerParameters) :
                 bloodGlucoseEndTime.toDate(),
                 timeZoneId,
                 recordProcessor.processGlucoseFromRecords(
-                    bloodGlucoseStartTime, bloodGlucoseEndTime, currentDevice, bloodGlucose
+                    currentDevice, bloodGlucose
                 ).samples.map { it.toQuantitySamplePayload() })
 
             reportStatus(VitalResource.Glucose, synced)
@@ -345,8 +345,6 @@ class UploadChangesWorker(appContext: Context, workerParams: WorkerParameters) :
                 sleepEndTime.toDate(),
                 timeZoneId,
                 recordProcessor.processSleepFromRecords(
-                    sleepStartTime,
-                    sleepEndTime,
                     currentDevice,
                     sleeps,
                     stages,
@@ -384,8 +382,6 @@ class UploadChangesWorker(appContext: Context, workerParams: WorkerParameters) :
                 activityEndTime.toDate(),
                 timeZoneId,
                 recordProcessor.processActivitiesFromRecords(
-                    activityStartTime,
-                    activityEndTime,
                     TimeZone.getDefault(),
                     currentDevice,
                     activeEnergyBurned,
@@ -417,7 +413,7 @@ class UploadChangesWorker(appContext: Context, workerParams: WorkerParameters) :
                 exercisesEndTime.toDate(),
                 timeZoneId,
                 recordProcessor.processWorkoutsFromRecords(
-                    exercisesStartTime, exercisesEndTime, currentDevice, exercises
+                    currentDevice, exercises
                 ).samples.map { it.toWorkoutPayload() })
 
             reportStatus(VitalResource.Workout, synced)
@@ -444,7 +440,7 @@ class UploadChangesWorker(appContext: Context, workerParams: WorkerParameters) :
                 bodyEndTime.toDate(),
                 timeZoneId,
                 recordProcessor.processBodyFromRecords(
-                    bodyStartTime, bodyEndTime, currentDevice, weights, bodyFats
+                    currentDevice, weights, bodyFats
                 ).toBodyPayload()
             )
             reportStatus(VitalResource.Body, synced)
@@ -465,7 +461,7 @@ class UploadChangesWorker(appContext: Context, workerParams: WorkerParameters) :
                 height.time.toDate(),
                 height.time.toDate(),
                 timeZoneId,
-                recordProcessor.processProfileFromRecords(height.time, height.time, heights)
+                recordProcessor.processProfileFromRecords(heights)
                     .toProfilePayload()
             )
             reportStatus(VitalResource.Profile, synced)


### PR DESCRIPTION
RecordProcessor is used to transform already read HC Records into Vital QuantitySamples.

This step should NOT need any knowledge of how the records were queried/supplied, including the query start & end time.

e.g., each sleep session record itself has start & end time, and any further processing should be based solely off what is in the record.

Remove this information that "leaked" through the abstraction.