### PR TITLE
VIT-3743: Generic VitalResource upload process

### DIFF
--- a/VitalClient/src/main/java/io/tryvital/client/services/VitalsService.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/VitalsService.kt
@@ -20,15 +20,6 @@ class VitalsService private constructor(private val timeSeries: TimeSeries) {
         )
     }
 
-    suspend fun sendGlucose(
-        userId: String,
-        glucosePayloads: TimeseriesPayload<List<QuantitySamplePayload>>,
-    ) {
-        return timeSeries.timeseriesPost(
-            userId = userId, resource = "glucose", payload = glucosePayloads,
-        )
-    }
-
     suspend fun getCholesterol(
         cholesterolType: CholesterolType,
         userId: String,
@@ -101,35 +92,14 @@ class VitalsService private constructor(private val timeSeries: TimeSeries) {
         )
     }
 
-    suspend fun sendHeartRate(
+    suspend fun sendQuantitySamples(
+        resource: IngestibleTimeseriesResource,
         userId: String,
         timeseriesPayload: TimeseriesPayload<List<QuantitySamplePayload>>
     ) {
         return timeSeries.timeseriesPost(
             userId = userId,
-            resource = "heartrate",
-            payload = timeseriesPayload
-        )
-    }
-
-    suspend fun sendHeartRateVariability(
-        userId: String,
-        timeseriesPayload: TimeseriesPayload<List<QuantitySamplePayload>>
-    ) {
-        return timeSeries.timeseriesPost(
-            userId = userId,
-            resource = "heartrate_variability",
-            payload = timeseriesPayload
-        )
-    }
-
-    suspend fun sendWater(
-        userId: String,
-        timeseriesPayload: TimeseriesPayload<List<QuantitySamplePayload>>
-    ) {
-        return timeSeries.timeseriesPost(
-            userId = userId,
-            resource = "water",
+            resource = resource.toString(),
             payload = timeseriesPayload
         )
     }

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/ProviderSlug.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/ProviderSlug.kt
@@ -5,6 +5,7 @@ package io.tryvital.client.services.data
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.adapters.EnumJsonAdapter
+import io.tryvital.client.utils.getJsonName
 
 @JsonClass(generateAdapter = false)
 enum class ManualProviderSlug {
@@ -73,6 +74,3 @@ enum class ProviderSlug {
             get() = EnumJsonAdapter.create(ProviderSlug::class.java).withUnknownFallback(Unrecognized)
     }
 }
-
-private fun getJsonName(value: Enum<*>) = value.javaClass
-    .getField(value.name).getAnnotation(Json::class.java)?.name ?: value.name

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Timeseries.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Timeseries.kt
@@ -1,6 +1,8 @@
 package io.tryvital.client.services.data
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import io.tryvital.client.utils.getJsonName
 import java.util.*
 
 data class TimeseriesPayload<T> (
@@ -17,3 +19,15 @@ data class TimeseriesPayload<T> (
     @Json(name = "data")
     val data: T
 )
+
+@JsonClass(generateAdapter = false)
+enum class IngestibleTimeseriesResource {
+    @Json(name = "glucose") BloodGlucose,
+    @Json(name = "water") Water,
+    @Json(name = "heartrate") HeartRate,
+    @Json(name = "heartrate_variability") HeartRateVariability;
+
+    // Use the Json name also when converting to string.
+    // This is intended for Retrofit request parameter serialization.
+    override fun toString() = getJsonName(this)
+}

--- a/VitalClient/src/main/java/io/tryvital/client/utils/enum.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/utils/enum.kt
@@ -1,0 +1,6 @@
+package io.tryvital.client.utils
+
+import com.squareup.moshi.Json
+
+internal fun getJsonName(value: Enum<*>) = value.javaClass
+    .getField(value.name).getAnnotation(Json::class.java)?.name ?: value.name

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/ProcessedResourceData.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/ProcessedResourceData.kt
@@ -2,6 +2,7 @@ package io.tryvital.vitalhealthconnect.model.processedresource
 
 import io.tryvital.client.services.data.BodyPayload
 import io.tryvital.client.services.data.ProfilePayload
+import io.tryvital.client.services.data.IngestibleTimeseriesResource
 import java.util.*
 
 sealed class ProcessedResourceData {
@@ -10,11 +11,8 @@ sealed class ProcessedResourceData {
 }
 
 sealed class TimeSeriesData {
-    data class Glucose(val samples: List<QuantitySample>) : TimeSeriesData()
     data class BloodPressure(val samples: List<BloodPressureSample>) : TimeSeriesData()
-    data class HeartRate(val samples: List<QuantitySample>) : TimeSeriesData()
-    data class HeartRateVariabilityRmssd(val samples: List<QuantitySample>) : TimeSeriesData()
-    data class Water(val samples: List<QuantitySample>) : TimeSeriesData()
+    data class QuantitySamples(val resource: IngestibleTimeseriesResource, val samples: List<QuantitySample>) : TimeSeriesData()
 }
 
 sealed class SummaryData {

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordProcessor.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordProcessor.kt
@@ -2,10 +2,10 @@ package io.tryvital.vitalhealthconnect.records
 
 import androidx.health.connect.client.records.*
 import androidx.health.connect.client.records.ExerciseSessionRecord.Companion.EXERCISE_TYPE_INT_TO_STRING_MAP
+import io.tryvital.client.services.data.IngestibleTimeseriesResource
 import io.tryvital.client.services.data.SampleType
 import io.tryvital.vitalhealthconnect.SupportedSleepApps
 import io.tryvital.vitalhealthconnect.ext.toDate
-import io.tryvital.vitalhealthconnect.model.HCActivitySummary
 import io.tryvital.vitalhealthconnect.model.HCQuantitySample
 import io.tryvital.vitalhealthconnect.model.processedresource.*
 import kotlinx.coroutines.*
@@ -27,23 +27,23 @@ interface RecordProcessor {
     suspend fun processGlucoseFromRecords(
         currentDevice: String,
         readBloodGlucose: List<BloodGlucoseRecord>
-    ): TimeSeriesData.Glucose
+    ): TimeSeriesData.QuantitySamples
 
     suspend fun processHeartRateFromRecords(
         currentDevice: String,
         heartRateRecords: List<HeartRateRecord>
-    ): TimeSeriesData.HeartRate
+    ): TimeSeriesData.QuantitySamples
 
 
     fun processHeartRateVariabilityRmssFromRecords(
         currentDevice: String,
         heartRateRecords: List<HeartRateVariabilityRmssdRecord>
-    ): TimeSeriesData.HeartRateVariabilityRmssd
+    ): TimeSeriesData.QuantitySamples
 
     fun processWaterFromRecords(
         currentDevice: String,
         readHydration: List<HydrationRecord>
-    ): TimeSeriesData.Water
+    ): TimeSeriesData.QuantitySamples
 
     suspend fun processBodyFromRecords(
         fallbackDeviceModel: String,
@@ -114,8 +114,9 @@ internal class HealthConnectRecordProcessor(
     override suspend fun processGlucoseFromRecords(
         currentDevice: String,
         readBloodGlucose: List<BloodGlucoseRecord>
-    ): TimeSeriesData.Glucose {
-        return TimeSeriesData.Glucose(
+    ): TimeSeriesData.QuantitySamples {
+        return TimeSeriesData.QuantitySamples(
+            IngestibleTimeseriesResource.BloodGlucose,
             readBloodGlucose.map {
                 HCQuantitySample(
                     value = it.level.inMilligramsPerDeciliter,
@@ -130,8 +131,9 @@ internal class HealthConnectRecordProcessor(
     override suspend fun processHeartRateFromRecords(
         currentDevice: String,
         heartRateRecords: List<HeartRateRecord>
-    ): TimeSeriesData.HeartRate {
-        return TimeSeriesData.HeartRate(
+    ): TimeSeriesData.QuantitySamples {
+        return TimeSeriesData.QuantitySamples(
+            IngestibleTimeseriesResource.HeartRate,
             mapHearthRate(heartRateRecords, currentDevice)
         )
     }
@@ -139,8 +141,9 @@ internal class HealthConnectRecordProcessor(
     override fun processHeartRateVariabilityRmssFromRecords(
         currentDevice: String,
         heartRateRecords: List<HeartRateVariabilityRmssdRecord>
-    ): TimeSeriesData.HeartRateVariabilityRmssd {
-        return TimeSeriesData.HeartRateVariabilityRmssd(
+    ): TimeSeriesData.QuantitySamples {
+        return TimeSeriesData.QuantitySamples(
+            IngestibleTimeseriesResource.HeartRateVariability,
             heartRateRecords.map {
                 HCQuantitySample(
                     value = it.heartRateVariabilityMillis,
@@ -157,8 +160,9 @@ internal class HealthConnectRecordProcessor(
     override fun processWaterFromRecords(
         currentDevice: String,
         readHydration: List<HydrationRecord>
-    ): TimeSeriesData.Water {
-        return TimeSeriesData.Water(
+    ): TimeSeriesData.QuantitySamples {
+        return TimeSeriesData.QuantitySamples(
+            IngestibleTimeseriesResource.Water,
             readHydration.map {
                 HCQuantitySample(
                     value = it.volume.inMilliliters,

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordUploader.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordUploader.kt
@@ -16,7 +16,6 @@ interface RecordUploader {
         sleepPayloads: List<SleepPayload>,
     )
 
-
     suspend fun uploadBody(
         userId: String,
         startDate: Date?,
@@ -49,44 +48,21 @@ interface RecordUploader {
         workoutPayloads: List<WorkoutPayload>,
     )
 
-    suspend fun uploadGlucose(
-        userId: String,
-        startDate: Date,
-        endDate: Date,
-        timeZoneId: String?,
-        glucosePayloads: List<QuantitySamplePayload>
-    )
-
     suspend fun uploadBloodPressure(
         userId: String,
-        startDate: Date,
-        endDate: Date,
+        startDate: Date?,
+        endDate: Date?,
         timeZoneId: String?,
         bloodPressurePayloads: List<BloodPressureSamplePayload>
     )
 
-    suspend fun uploadHeartRate(
+    suspend fun uploadQuantitySamples(
+        resource: IngestibleTimeseriesResource,
         userId: String,
-        startDate: Date,
-        endDate: Date,
+        startDate: Date?,
+        endDate: Date?,
         timeZoneId: String?,
-        heartRatePayloads: List<QuantitySamplePayload>
-    )
-
-    suspend fun uploadHeartRateVariability(
-        userId: String,
-        startDate: Date,
-        endDate: Date,
-        timeZoneId: String?,
-        heartRatePayloads: List<QuantitySamplePayload>
-    )
-
-    suspend fun uploadWater(
-        userId: String,
-        startDate: Date,
-        endDate: Date,
-        timeZoneId: String?,
-        waterPayloads: List<QuantitySamplePayload>
+        quantitySamples: List<QuantitySamplePayload>
     )
 }
 
@@ -192,22 +168,23 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         }
     }
 
-    override suspend fun uploadGlucose(
+    override suspend fun uploadQuantitySamples(
+        resource: IngestibleTimeseriesResource,
         userId: String,
-        startDate: Date,
-        endDate: Date,
+        startDate: Date?,
+        endDate: Date?,
         timeZoneId: String?,
-        glucosePayloads: List<QuantitySamplePayload>
+        quantitySamples: List<QuantitySamplePayload>
     ) {
-        if (glucosePayloads.isNotEmpty()) {
-            vitalClient.vitalsService.sendGlucose(
-                userId, TimeseriesPayload(
+        if (quantitySamples.isNotEmpty()) {
+            vitalClient.vitalsService.sendQuantitySamples(
+                resource, userId, TimeseriesPayload(
                     stage = stage,
                     provider = ManualProviderSlug.HealthConnect,
                     startDate = startDate,
                     endDate = endDate,
                     timeZoneId = timeZoneId,
-                    data = glucosePayloads,
+                    data = quantitySamples,
                 )
             )
         }
@@ -215,8 +192,8 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
 
     override suspend fun uploadBloodPressure(
         userId: String,
-        startDate: Date,
-        endDate: Date,
+        startDate: Date?,
+        endDate: Date?,
         timeZoneId: String?,
         bloodPressurePayloads: List<BloodPressureSamplePayload>
     ) {
@@ -229,69 +206,6 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
                     endDate = endDate,
                     timeZoneId = timeZoneId,
                     data = bloodPressurePayloads,
-                )
-            )
-        }
-    }
-
-    override suspend fun uploadHeartRate(
-        userId: String,
-        startDate: Date,
-        endDate: Date,
-        timeZoneId: String?,
-        heartRatePayloads: List<QuantitySamplePayload>
-    ) {
-        if (heartRatePayloads.isNotEmpty()) {
-            vitalClient.vitalsService.sendHeartRate(
-                userId, TimeseriesPayload(
-                    stage = stage,
-                    provider = ManualProviderSlug.HealthConnect,
-                    startDate = startDate,
-                    endDate = endDate,
-                    timeZoneId = timeZoneId,
-                    data = heartRatePayloads,
-                )
-            )
-        }
-    }
-
-    override suspend fun uploadHeartRateVariability(
-        userId: String,
-        startDate: Date,
-        endDate: Date,
-        timeZoneId: String?,
-        heartRatePayloads: List<QuantitySamplePayload>
-    ) {
-        if (heartRatePayloads.isNotEmpty()) {
-            vitalClient.vitalsService.sendHeartRateVariability(
-                userId, TimeseriesPayload(
-                    stage = stage,
-                    provider = ManualProviderSlug.HealthConnect,
-                    startDate = startDate,
-                    endDate = endDate,
-                    timeZoneId = timeZoneId,
-                    data = heartRatePayloads,
-                )
-            )
-        }
-    }
-
-    override suspend fun uploadWater(
-        userId: String,
-        startDate: Date,
-        endDate: Date,
-        timeZoneId: String?,
-        waterPayloads: List<QuantitySamplePayload>
-    ) {
-        if (waterPayloads.isNotEmpty()) {
-            vitalClient.vitalsService.sendWater(
-                userId, TimeseriesPayload(
-                    stage = stage,
-                    provider = ManualProviderSlug.HealthConnect,
-                    startDate = startDate,
-                    endDate = endDate,
-                    timeZoneId = timeZoneId,
-                    data = waterPayloads,
                 )
             )
         }

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/UploadAllDataWorker.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/UploadAllDataWorker.kt
@@ -9,6 +9,7 @@ import androidx.work.WorkerParameters
 import io.tryvital.client.Environment
 import io.tryvital.client.Region
 import io.tryvital.client.VitalClient
+import io.tryvital.client.services.data.IngestibleTimeseriesResource
 import io.tryvital.client.utils.VitalLogger
 import io.tryvital.vitalhealthconnect.*
 import io.tryvital.vitalhealthconnect.ext.toDate
@@ -159,7 +160,9 @@ class UploadAllDataWorker(appContext: Context, workerParams: WorkerParameters) :
         if (waters.samples.isEmpty()) {
             reportStatus(VitalResource.Water, nothingToSync)
         } else {
-            recordUploader.uploadWater(userId,
+            recordUploader.uploadQuantitySamples(
+                IngestibleTimeseriesResource.Water,
+                userId,
                 startDate,
                 endDate,
                 timeZoneId,
@@ -184,7 +187,9 @@ class UploadAllDataWorker(appContext: Context, workerParams: WorkerParameters) :
         if (heartRatePayloads.samples.isEmpty()) {
             reportStatus(VitalResource.HeartRate, nothingToSync)
         } else {
-            recordUploader.uploadHeartRate(userId,
+            recordUploader.uploadQuantitySamples(
+                IngestibleTimeseriesResource.HeartRate,
+                userId,
                 startDate,
                 endDate,
                 timeZoneId,
@@ -210,7 +215,9 @@ class UploadAllDataWorker(appContext: Context, workerParams: WorkerParameters) :
         if (heartRatePayloads.samples.isEmpty()) {
             reportStatus(VitalResource.HeartRateVariability, nothingToSync)
         } else {
-            recordUploader.uploadHeartRateVariability(userId,
+            recordUploader.uploadQuantitySamples(
+                IngestibleTimeseriesResource.HeartRateVariability,
+                userId,
                 startDate,
                 endDate,
                 timeZoneId,
@@ -262,7 +269,9 @@ class UploadAllDataWorker(appContext: Context, workerParams: WorkerParameters) :
         if (glucosePayloads.samples.isEmpty()) {
             reportStatus(VitalResource.Glucose, nothingToSync)
         } else {
-            recordUploader.uploadGlucose(userId,
+            recordUploader.uploadQuantitySamples(
+                IngestibleTimeseriesResource.BloodGlucose,
+                userId,
                 startDate,
                 endDate,
                 timeZoneId,

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/UploadChangesWorker.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/UploadChangesWorker.kt
@@ -15,6 +15,7 @@ import io.tryvital.client.Environment
 import io.tryvital.client.Region
 import io.tryvital.client.VITAL_PERFS_FILE_NAME
 import io.tryvital.client.VitalClient
+import io.tryvital.client.services.data.IngestibleTimeseriesResource
 import io.tryvital.client.utils.VitalLogger
 import io.tryvital.vitalhealthconnect.*
 import io.tryvital.vitalhealthconnect.ext.toDate
@@ -242,7 +243,9 @@ class UploadChangesWorker(appContext: Context, workerParams: WorkerParameters) :
             val waterStartTime = water.minOf { it.startTime }
             val waterEndTime = water.maxOf { it.endTime }
 
-            recordUploader.uploadWater(userId,
+            recordUploader.uploadQuantitySamples(
+                IngestibleTimeseriesResource.Water,
+                userId,
                 waterStartTime.toDate(),
                 waterEndTime.toDate(),
                 timeZoneId,
@@ -264,7 +267,9 @@ class UploadChangesWorker(appContext: Context, workerParams: WorkerParameters) :
             val heartRateStartTime = heartRate.minOf { it.startTime }
             val heartRateEndTime = heartRate.maxOf { it.endTime }
 
-            recordUploader.uploadHeartRate(userId,
+            recordUploader.uploadQuantitySamples(
+                IngestibleTimeseriesResource.HeartRate,
+                userId,
                 heartRateStartTime.toDate(),
                 heartRateEndTime.toDate(),
                 timeZoneId,
@@ -289,7 +294,9 @@ class UploadChangesWorker(appContext: Context, workerParams: WorkerParameters) :
             val heartRateStartTime = rmssdRecords.minOf { it.time }
             val heartRateEndTime = rmssdRecords.maxOf { it.time }
 
-            recordUploader.uploadHeartRateVariability(userId,
+            recordUploader.uploadQuantitySamples(
+                IngestibleTimeseriesResource.HeartRateVariability,
+                userId,
                 heartRateStartTime.toDate(),
                 heartRateEndTime.toDate(),
                 timeZoneId,
@@ -314,7 +321,9 @@ class UploadChangesWorker(appContext: Context, workerParams: WorkerParameters) :
             val bloodGlucoseStartTime = bloodGlucose.minOf { it.time }
             val bloodGlucoseEndTime = bloodGlucose.maxOf { it.time }
 
-            recordUploader.uploadGlucose(userId,
+            recordUploader.uploadQuantitySamples(
+                IngestibleTimeseriesResource.BloodGlucose,
+                userId,
                 bloodGlucoseStartTime.toDate(),
                 bloodGlucoseEndTime.toDate(),
                 timeZoneId,

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/uploadResources.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/uploadResources.kt
@@ -1,0 +1,53 @@
+package io.tryvital.vitalhealthconnect.workers
+
+import io.tryvital.vitalhealthconnect.model.processedresource.ProcessedResourceData
+import io.tryvital.vitalhealthconnect.model.processedresource.SummaryData
+import io.tryvital.vitalhealthconnect.model.processedresource.TimeSeriesData
+import io.tryvital.vitalhealthconnect.records.RecordUploader
+import java.util.Date
+
+internal suspend fun uploadResources(
+    data: ProcessedResourceData,
+    uploader: RecordUploader,
+    userId: String,
+    start: Date?,
+    end: Date?,
+    timeZoneId: String
+) {
+    when (data) {
+        is ProcessedResourceData.Summary -> when (data.summaryData) {
+            is SummaryData.Activities -> uploader.uploadActivities(
+                userId, start, end, timeZoneId,
+                data.summaryData.activities.map { it.toActivityPayload() }
+            )
+            is SummaryData.Body -> uploader.uploadBody(
+                userId, start, end, timeZoneId,
+                data.summaryData.toBodyPayload()
+            )
+            is SummaryData.Profile -> uploader.uploadProfile(
+                userId, start, end, timeZoneId,
+                data.summaryData.toProfilePayload()
+            )
+            is SummaryData.Sleeps -> uploader.uploadSleeps(
+                userId, start, end, timeZoneId,
+                data.summaryData.samples.map { it.toSleepPayload() }
+            )
+            is SummaryData.Workouts -> uploader.uploadWorkouts(
+                userId, start, end, timeZoneId,
+                data.summaryData.samples.map { it.toWorkoutPayload() }
+            )
+        }
+
+        is ProcessedResourceData.TimeSeries -> when (data.timeSeriesData) {
+            is TimeSeriesData.BloodPressure -> uploader.uploadBloodPressure(
+                userId, start, end, timeZoneId,
+                data.timeSeriesData.samples.map { it.toBloodPressurePayload() }
+            )
+            is TimeSeriesData.QuantitySamples -> uploader.uploadQuantitySamples(
+                data.timeSeriesData.resource,
+                userId, start, end, timeZoneId,
+                data.timeSeriesData.samples.map { it.toQuantitySamplePayload() },
+            )
+        }
+    }
+}


### PR DESCRIPTION
Create a generic `uploadResources` helper function which accepts any Vital SDK raw schema (`ProcessedResourceData`) and uploads them to Vital's data ingestion API endpoints.

This PR also refactored most timeseries sample upload API to be generically accepting resource type + a list of QuantitySample, in order to simplify the implementation and not requiring a new method for each odd resource type.


