### PR TITLE
VIT-3764: Send historical stage in one big upload

### DIFF
--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/ProcessedResourceData.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/ProcessedResourceData.kt
@@ -3,19 +3,49 @@ package io.tryvital.vitalhealthconnect.model.processedresource
 import io.tryvital.client.services.data.BodyPayload
 import io.tryvital.client.services.data.ProfilePayload
 import io.tryvital.client.services.data.IngestibleTimeseriesResource
+import java.lang.IllegalArgumentException
 import java.util.*
 
 sealed class ProcessedResourceData {
     data class Summary(val summaryData: SummaryData) : ProcessedResourceData()
     data class TimeSeries(val timeSeriesData: TimeSeriesData) : ProcessedResourceData()
+
+    /**
+     * Merge two `ProcessedResourceData`s into one
+     * Older data should be on the LHS; Newer on the RHS.
+     */
+    fun merge(other: ProcessedResourceData): ProcessedResourceData {
+        if (this is Summary && other is Summary) {
+            return Summary(summaryData.merge(other.summaryData))
+        }
+        if (this is TimeSeries && other is TimeSeries) {
+            return TimeSeries(timeSeriesData.merge(other.timeSeriesData))
+        }
+        throw IllegalArgumentException("cannot merge two different cases of ProcessedResourceData")
+    }
 }
 
 sealed class TimeSeriesData {
-    data class BloodPressure(val samples: List<BloodPressureSample>) : TimeSeriesData()
-    data class QuantitySamples(val resource: IngestibleTimeseriesResource, val samples: List<QuantitySample>) : TimeSeriesData()
+    abstract fun merge(other: TimeSeriesData): TimeSeriesData
+
+    data class BloodPressure(val samples: List<BloodPressureSample>) : TimeSeriesData() {
+        override fun merge(other: TimeSeriesData): TimeSeriesData {
+            check(other is BloodPressure)
+            return BloodPressure(samples + other.samples)
+        }
+    }
+
+    data class QuantitySamples(val resource: IngestibleTimeseriesResource, val samples: List<QuantitySample>) : TimeSeriesData() {
+        override fun merge(other: TimeSeriesData): TimeSeriesData {
+            check(other is QuantitySamples && resource == other.resource)
+            return QuantitySamples(resource, samples + other.samples)
+        }
+    }
 }
 
 sealed class SummaryData {
+    abstract fun merge(other: SummaryData): SummaryData
+
     data class Profile(
         val biologicalSex: String,
         val dateOfBirth: Date,
@@ -28,6 +58,12 @@ sealed class SummaryData {
                 dateOfBirth = dateOfBirth,
                 heightInCm = heightInCm,
             )
+        }
+
+        override fun merge(other: SummaryData): SummaryData {
+            check(other is Profile)
+            // RHS bias
+            return other
         }
     }
 
@@ -42,18 +78,41 @@ sealed class SummaryData {
                 bodyFatPercentage = bodyFatPercentage.map { it.toQuantitySamplePayload() },
             )
         }
+
+        override fun merge(other: SummaryData): SummaryData {
+            check(other is Body)
+            // RHS bias
+            return other
+        }
     }
 
     data class Activities(
         val activities: List<Activity>
-    ) : SummaryData()
+    ) : SummaryData() {
+        override fun merge(other: SummaryData): SummaryData {
+            check(other is Activities)
+            return Activities(activities + other.activities)
+        }
+    }
 
     data class Sleeps(
         val samples: List<Sleep>
-    ) : SummaryData()
+    ) : SummaryData() {
+        override fun merge(other: SummaryData): SummaryData {
+            check(other is Sleeps)
+            return Sleeps(samples + other.samples)
+        }
+    }
 
     data class Workouts(
         val samples: List<Workout>
-    ) : SummaryData()
+    ) : SummaryData() {
+        override fun merge(other: SummaryData): SummaryData {
+            check(other is Workouts)
+            return Workouts(samples + other.samples)
+        }
+    }
 }
 
+fun Collection<ProcessedResourceData>.merged(): ProcessedResourceData
+    = reduce { acc, next -> acc.merge(next) }

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordUploader.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordUploader.kt
@@ -4,7 +4,6 @@ import io.tryvital.client.VitalClient
 import io.tryvital.client.services.data.*
 import java.util.*
 
-private val stage = DataStage.Daily
 
 interface RecordUploader {
 
@@ -14,6 +13,7 @@ interface RecordUploader {
         endDate: Date?,
         timeZoneId: String?,
         sleepPayloads: List<SleepPayload>,
+        stage: DataStage = DataStage.Daily,
     )
 
     suspend fun uploadBody(
@@ -21,7 +21,8 @@ interface RecordUploader {
         startDate: Date?,
         endDate: Date?,
         timeZoneId: String?,
-        bodyPayload: BodyPayload
+        bodyPayload: BodyPayload,
+        stage: DataStage = DataStage.Daily,
     )
 
     suspend fun uploadProfile(
@@ -29,7 +30,8 @@ interface RecordUploader {
         startDate: Date?,
         endDate: Date?,
         timeZoneId: String?,
-        profilePayload: ProfilePayload
+        profilePayload: ProfilePayload,
+        stage: DataStage = DataStage.Daily,
     )
 
     suspend fun uploadActivities(
@@ -38,6 +40,7 @@ interface RecordUploader {
         endDate: Date?,
         timeZoneId: String?,
         activityPayloads: List<ActivityPayload>,
+        stage: DataStage = DataStage.Daily,
     )
 
     suspend fun uploadWorkouts(
@@ -46,6 +49,7 @@ interface RecordUploader {
         endDate: Date?,
         timeZoneId: String?,
         workoutPayloads: List<WorkoutPayload>,
+        stage: DataStage = DataStage.Daily,
     )
 
     suspend fun uploadBloodPressure(
@@ -53,7 +57,8 @@ interface RecordUploader {
         startDate: Date?,
         endDate: Date?,
         timeZoneId: String?,
-        bloodPressurePayloads: List<BloodPressureSamplePayload>
+        bloodPressurePayloads: List<BloodPressureSamplePayload>,
+        stage: DataStage = DataStage.Daily,
     )
 
     suspend fun uploadQuantitySamples(
@@ -62,7 +67,8 @@ interface RecordUploader {
         startDate: Date?,
         endDate: Date?,
         timeZoneId: String?,
-        quantitySamples: List<QuantitySamplePayload>
+        quantitySamples: List<QuantitySamplePayload>,
+        stage: DataStage = DataStage.Daily,
     )
 }
 
@@ -73,6 +79,7 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         endDate: Date?,
         timeZoneId: String?,
         sleepPayloads: List<SleepPayload>,
+        stage: DataStage,
     ) {
         if (sleepPayloads.isNotEmpty()) {
             vitalClient.summaryService.addSleeps(
@@ -93,7 +100,8 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         startDate: Date?,
         endDate: Date?,
         timeZoneId: String?,
-        bodyPayload: BodyPayload
+        bodyPayload: BodyPayload,
+        stage: DataStage,
     ) {
         vitalClient.summaryService.addBody(
             userId, SummaryPayload(
@@ -112,7 +120,8 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         startDate: Date?,
         endDate: Date?,
         timeZoneId: String?,
-        profilePayload: ProfilePayload
+        profilePayload: ProfilePayload,
+        stage: DataStage,
     ) {
         vitalClient.summaryService.addProfile(
             userId, SummaryPayload(
@@ -132,6 +141,7 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         endDate: Date?,
         timeZoneId: String?,
         activityPayloads: List<ActivityPayload>,
+        stage: DataStage,
     ) {
         if (activityPayloads.isNotEmpty()) {
             vitalClient.summaryService.addActivities(
@@ -153,6 +163,7 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         endDate: Date?,
         timeZoneId: String?,
         workoutPayloads: List<WorkoutPayload>,
+        stage: DataStage,
     ) {
         if (workoutPayloads.isNotEmpty()) {
             vitalClient.summaryService.addWorkouts(
@@ -174,7 +185,8 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         startDate: Date?,
         endDate: Date?,
         timeZoneId: String?,
-        quantitySamples: List<QuantitySamplePayload>
+        quantitySamples: List<QuantitySamplePayload>,
+        stage: DataStage,
     ) {
         if (quantitySamples.isNotEmpty()) {
             vitalClient.vitalsService.sendQuantitySamples(
@@ -195,7 +207,8 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         startDate: Date?,
         endDate: Date?,
         timeZoneId: String?,
-        bloodPressurePayloads: List<BloodPressureSamplePayload>
+        bloodPressurePayloads: List<BloodPressureSamplePayload>,
+        stage: DataStage,
     ) {
         if (bloodPressurePayloads.isNotEmpty()) {
             vitalClient.vitalsService.sendBloodPressure(

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/uploadResources.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/uploadResources.kt
@@ -1,5 +1,6 @@
 package io.tryvital.vitalhealthconnect.workers
 
+import io.tryvital.client.services.data.DataStage
 import io.tryvital.vitalhealthconnect.model.processedresource.ProcessedResourceData
 import io.tryvital.vitalhealthconnect.model.processedresource.SummaryData
 import io.tryvital.vitalhealthconnect.model.processedresource.TimeSeriesData
@@ -9,44 +10,52 @@ import java.util.Date
 internal suspend fun uploadResources(
     data: ProcessedResourceData,
     uploader: RecordUploader,
+    stage: DataStage,
     userId: String,
-    start: Date?,
-    end: Date?,
+    start: Date? = null,
+    end: Date? = null,
     timeZoneId: String
 ) {
     when (data) {
         is ProcessedResourceData.Summary -> when (data.summaryData) {
             is SummaryData.Activities -> uploader.uploadActivities(
                 userId, start, end, timeZoneId,
-                data.summaryData.activities.map { it.toActivityPayload() }
+                data.summaryData.activities.map { it.toActivityPayload() },
+                stage,
             )
             is SummaryData.Body -> uploader.uploadBody(
                 userId, start, end, timeZoneId,
-                data.summaryData.toBodyPayload()
+                data.summaryData.toBodyPayload(),
+                stage,
             )
             is SummaryData.Profile -> uploader.uploadProfile(
                 userId, start, end, timeZoneId,
-                data.summaryData.toProfilePayload()
+                data.summaryData.toProfilePayload(),
+                stage,
             )
             is SummaryData.Sleeps -> uploader.uploadSleeps(
                 userId, start, end, timeZoneId,
-                data.summaryData.samples.map { it.toSleepPayload() }
+                data.summaryData.samples.map { it.toSleepPayload() },
+                stage,
             )
             is SummaryData.Workouts -> uploader.uploadWorkouts(
                 userId, start, end, timeZoneId,
-                data.summaryData.samples.map { it.toWorkoutPayload() }
+                data.summaryData.samples.map { it.toWorkoutPayload() },
+                stage,
             )
         }
 
         is ProcessedResourceData.TimeSeries -> when (data.timeSeriesData) {
             is TimeSeriesData.BloodPressure -> uploader.uploadBloodPressure(
                 userId, start, end, timeZoneId,
-                data.timeSeriesData.samples.map { it.toBloodPressurePayload() }
+                data.timeSeriesData.samples.map { it.toBloodPressurePayload() },
+                stage,
             )
             is TimeSeriesData.QuantitySamples -> uploader.uploadQuantitySamples(
                 data.timeSeriesData.resource,
                 userId, start, end, timeZoneId,
                 data.timeSeriesData.samples.map { it.toQuantitySamplePayload() },
+                stage,
             )
         }
     }


### PR DESCRIPTION
* Mark uploads with historical vs daily stage correctly

* Merge all `ProcessedResourceData`s in the historical stage into one instance chronologically, and do only one upload (the merged version) like vital-ios. Descope SDK-side chunking for now, which needs to be properly designed to deal with edge cases, etc.

