### PR TITLE
VIT-2854: Enable ResourceSyncWorker

### DIFF
--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncWorker.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncWorker.kt
@@ -162,7 +162,8 @@ class ResourceSyncWorker(appContext: Context, workerParams: WorkerParameters) :
             is ResourceSyncState.Incremental -> incrementalBackfill(state, timeZone)
         }
 
-        return Result.failure()
+        // TODO: Report synced vs nothing to sync
+        return Result.success()
     }
 
     private suspend fun historicalBackfill(state: ResourceSyncState.Historical, timeZone: TimeZone) {
@@ -284,16 +285,6 @@ class ResourceSyncWorker(appContext: Context, workerParams: WorkerParameters) :
         sharedPreferences.edit()
             .putJson<ResourceSyncState>(input.resource.syncStateKey, newState)
             .apply()
-    }
-
-    private suspend fun reportStatus(resource: VitalResource, status: String) {
-        setProgress(
-            Data.Builder()
-                .putString(statusTypeKey, resource.name)
-                .putString(syncStatusKey, status)
-                .build()
-        )
-        delay(100)
     }
 }
 


### PR DESCRIPTION
Integrate the new ResourceSyncWorker into the HC SDK Client.

The new process:

1. We get the list of resources with read permission granted

2. We spawn a `ResourceSyncWorker` for each of these resources.

3. We wait for all the spawned workers to complete.


