### PR TITLE
VIT-2859: Singletonize the SDK

### DIFF
--- a/VitalClient/src/main/java/io/tryvital/client/Configuration.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/Configuration.kt
@@ -1,7 +1,40 @@
 package io.tryvital.client
 
-data class Configuration(
-    val apiKey: String,
-    val region: Region,
-    val environment: Environment
-)
+import android.content.SharedPreferences
+
+const val VITAL_ENCRYPTED_USER_ID_KEY: String = "userId"
+const val VITAL_ENCRYPTED_REGION_KEY = "region"
+const val VITAL_ENCRYPTED_ENVIRONMENT_KEY = "environment"
+const val VITAL_ENCRYPTED_API_KEY_KEY = "apiKey"
+
+internal interface ConfigurationReader {
+    val userId: String?
+    val region: Region?
+    val environment: Environment?
+    val apiKey: String?
+}
+
+@JvmInline
+internal value class SharedPreferencesConfigurationReader(
+    private val sharedPreferences: SharedPreferences
+): ConfigurationReader {
+    override val userId: String? get() = sharedPreferences.getString(VITAL_ENCRYPTED_USER_ID_KEY, null)
+    override val region: Region?
+        get() = sharedPreferences.getString(VITAL_ENCRYPTED_REGION_KEY, null)
+            ?.let { Region.valueOf(it) }
+    override val environment: Environment?
+        get() = sharedPreferences.getString(
+            VITAL_ENCRYPTED_ENVIRONMENT_KEY,
+            null
+        )?.let { Environment.valueOf(it) }
+    override val apiKey: String? get() = sharedPreferences.getString(VITAL_ENCRYPTED_API_KEY_KEY, null)
+}
+
+internal data class StaticConfiguration(
+    override val region: Region? = null,
+    override val environment: Environment? = null,
+    override val apiKey: String? = null,
+    override val userId: String? = null,
+): ConfigurationReader
+
+class VitalClientUnconfigured: Throwable("VitalClient has not been configured.")

--- a/VitalClient/src/main/java/io/tryvital/client/utils/ApiKeyInterceptor.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/utils/ApiKeyInterceptor.kt
@@ -1,10 +1,13 @@
 package io.tryvital.client.utils
 
+import io.tryvital.client.ConfigurationReader
+import io.tryvital.client.VitalClientUnconfigured
 import okhttp3.Interceptor
 import okhttp3.Response
 
-class ApiKeyInterceptor(val apiKey: String): Interceptor {
+internal class ApiKeyInterceptor(private val configurationReader: ConfigurationReader): Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
+        val apiKey = configurationReader.apiKey ?: throw VitalClientUnconfigured()
         val request = chain.request().newBuilder().addHeader("x-vital-api-key", apiKey).build()
         return chain.proceed(request)
     }

--- a/VitalClient/src/test/java/io/tryvital/client/ActivityServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/ActivityServiceTest.kt
@@ -19,10 +19,9 @@ class ActivityServiceTest {
     @Before
     fun setUp() {
         server = MockWebServer()
-
         retrofit = Dependencies.createRetrofit(
             server.url("").toString(),
-            Dependencies.createHttpClient(apiKey = apiKey),
+            Dependencies.createHttpClient(null, StaticConfiguration(apiKey = apiKey)),
             Dependencies.createMoshi()
         )
     }

--- a/VitalClient/src/test/java/io/tryvital/client/BodyServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/BodyServiceTest.kt
@@ -23,7 +23,7 @@ class BodyServiceTest {
 
         retrofit = Dependencies.createRetrofit(
             server.url("").toString(),
-            Dependencies.createHttpClient(apiKey = apiKey),
+            Dependencies.createHttpClient(null, StaticConfiguration(apiKey = apiKey)),
             Dependencies.createMoshi()
         )
     }

--- a/VitalClient/src/test/java/io/tryvital/client/LinkServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/LinkServiceTest.kt
@@ -22,7 +22,7 @@ class LinkServiceTest {
 
         retrofit = Dependencies.createRetrofit(
             server.url("").toString(),
-            Dependencies.createHttpClient(apiKey = apiKey),
+            Dependencies.createHttpClient(null, StaticConfiguration(apiKey = apiKey)),
             Dependencies.createMoshi()
         )
     }

--- a/VitalClient/src/test/java/io/tryvital/client/ProfileServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/ProfileServiceTest.kt
@@ -22,7 +22,7 @@ class ProfileServiceTest {
 
         retrofit = Dependencies.createRetrofit(
             server.url("").toString(),
-            Dependencies.createHttpClient(apiKey = apiKey),
+            Dependencies.createHttpClient(null, StaticConfiguration(apiKey = apiKey)),
             Dependencies.createMoshi()
         )
     }

--- a/VitalClient/src/test/java/io/tryvital/client/SleepServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/SleepServiceTest.kt
@@ -24,7 +24,7 @@ class SleepServiceTest {
 
         retrofit = Dependencies.createRetrofit(
             server.url("").toString(),
-            Dependencies.createHttpClient(apiKey = apiKey),
+            Dependencies.createHttpClient(null, StaticConfiguration(apiKey = apiKey)),
             Dependencies.createMoshi()
         )
     }

--- a/VitalClient/src/test/java/io/tryvital/client/SummaryServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/SummaryServiceTest.kt
@@ -23,7 +23,7 @@ class SummaryServiceTest {
 
         retrofit = Dependencies.createRetrofit(
             server.url("").toString(),
-            Dependencies.createHttpClient(apiKey = apiKey),
+            Dependencies.createHttpClient(null, StaticConfiguration(apiKey = apiKey)),
             Dependencies.createMoshi()
         )
     }

--- a/VitalClient/src/test/java/io/tryvital/client/TestkitServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/TestkitServiceTest.kt
@@ -28,7 +28,7 @@ class TestkitServiceTest {
 
         retrofit = Dependencies.createRetrofit(
             server.url("").toString(),
-            Dependencies.createHttpClient(apiKey = apiKey),
+            Dependencies.createHttpClient(null, StaticConfiguration(apiKey = apiKey)),
             Dependencies.createMoshi()
         )
     }

--- a/VitalClient/src/test/java/io/tryvital/client/UserServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/UserServiceTest.kt
@@ -26,7 +26,7 @@ class UserServiceTest {
 
         retrofit = Dependencies.createRetrofit(
             server.url("").toString(),
-            Dependencies.createHttpClient(apiKey = apiKey),
+            Dependencies.createHttpClient(null, StaticConfiguration(apiKey = apiKey)),
             Dependencies.createMoshi()
         )
     }

--- a/VitalClient/src/test/java/io/tryvital/client/VitalsServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/VitalsServiceTest.kt
@@ -24,7 +24,7 @@ class VitalsServiceTest {
 
         retrofit = Dependencies.createRetrofit(
             server.url("").toString(),
-            Dependencies.createHttpClient(apiKey = apiKey),
+            Dependencies.createHttpClient(null, StaticConfiguration(apiKey = apiKey)),
             Dependencies.createMoshi()
         )
     }

--- a/VitalClient/src/test/java/io/tryvital/client/WorkoutServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/WorkoutServiceTest.kt
@@ -22,7 +22,7 @@ class WorkoutServiceTest {
 
         retrofit = Dependencies.createRetrofit(
             server.url("").toString(),
-            Dependencies.createHttpClient(apiKey = apiKey),
+            Dependencies.createHttpClient(null, StaticConfiguration(apiKey = apiKey)),
             Dependencies.createMoshi()
         )
     }

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncWorker.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncWorker.kt
@@ -46,17 +46,9 @@ internal val moshi by lazy {
 
 data class ResourceSyncWorkerInput(
     val resource: VitalResource,
-
-    // TODO: Remove after SDK singletonization
-    val region: Region,
-    val environment: Environment,
-    val apiKey: String,
 ) {
     fun toData(): Data = Data.Builder().run {
         putString("resource", resource.toString())
-        putString("environment", environment.name)
-        putString("region", region.name)
-        putString("apiKey", apiKey)
         build()
     }
 
@@ -65,13 +57,6 @@ data class ResourceSyncWorkerInput(
             resource = VitalResource.valueOf(
                 data.getString("resource") ?: throw IllegalArgumentException("Missing resource")
             ),
-            environment = Environment.valueOf(
-                data.getString("environment") ?: throw IllegalArgumentException("Missing environment")
-            ),
-            region = Region.valueOf(
-                data.getString("region") ?: throw IllegalArgumentException("Missing region")
-            ),
-            apiKey = data.getString("apiKey") ?: throw IllegalArgumentException("Missing API key"),
         )
     }
 }
@@ -96,7 +81,7 @@ class ResourceSyncWorker(appContext: Context, workerParams: WorkerParameters) :
     }
 
     private val vitalClient: VitalClient by lazy {
-        VitalClient(applicationContext, input.region, input.environment, input.apiKey)
+        VitalClient.getOrCreate(applicationContext)
     }
     private val sharedPreferences: SharedPreferences get() = vitalClient.sharedPreferences
     private val healthConnectClientProvider by lazy { HealthConnectClientProvider() }

--- a/app/src/main/java/io/tryvital/sample/VitalApp.kt
+++ b/app/src/main/java/io/tryvital/sample/VitalApp.kt
@@ -13,15 +13,8 @@ val region = Region.US
 val environment = Environment.Sandbox
 
 class VitalApp : Application() {
-    val client by lazy {
-        VitalClient(
-            context = this,
-            region = region,
-            environment = environment,
-            apiKey = apiKey
-        ).apply {
-            configure()
-        }
+    val client = VitalClient.getOrCreate(applicationContext).apply {
+        configure(region, environment, apiKey)
     }
 
     val userRepository by lazy {
@@ -29,7 +22,7 @@ class VitalApp : Application() {
     }
 
     val vitalHealthConnectManager by lazy {
-        VitalHealthConnectManager.create(this, client).apply {
+        VitalHealthConnectManager.getOrCreate(this).apply {
             configureHealthConnectClient()
         }
     }

--- a/app/src/main/java/io/tryvital/sample/ui/healthconnect/HealthConnectViewModel.kt
+++ b/app/src/main/java/io/tryvital/sample/ui/healthconnect/HealthConnectViewModel.kt
@@ -26,7 +26,7 @@ class HealthConnectViewModel(
     private val userRepository: UserRepository
 ) : ViewModel() {
     private val isCurrentSDKUser
-        get() = userRepository.selectedUser!!.userId == vitalHealthConnectManager.vitalClient.currentUserId
+        get() = userRepository.selectedUser!!.userId == vitalClient.currentUserId
 
     private val viewModelState =
         MutableStateFlow(HealthConnectViewModelState(
@@ -51,11 +51,10 @@ class HealthConnectViewModel(
     fun toggleSDKCurrentUserState() {
         if (isCurrentSDKUser) {
             vitalHealthConnectManager.cleanUp()
-            vitalHealthConnectManager.vitalClient.cleanUp()
+            vitalClient.cleanUp()
         } else {
-            vitalClient.configure()
             vitalHealthConnectManager.configureHealthConnectClient()
-            vitalHealthConnectManager.vitalClient.setUserId(
+            vitalClient.setUserId(
                 userRepository.selectedUser!!.userId
             )
         }


### PR DESCRIPTION
Singletonize both VitalClient and VitalHealthConnectClient:

* VitalClient.getOrCreate(android.Context)
* VitalHealthConnectClient.getOrCreate(android.Context)

Passing in the Android Application Context is a standard singleton pattern on Android, e.g., [WorkManager.getInstance](https://developer.android.com/reference/androidx/work/WorkManager#getInstance(android.content.Context))


