### PR TITLE
VIT-3963: Start Foreground Service only once for each batch of requested resources

### DIFF
--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/types.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/types.kt
@@ -5,5 +5,5 @@ import android.content.Context
 import io.tryvital.vitalhealthconnect.model.VitalResource
 
 interface SyncNotificationBuilder {
-    fun build(context: Context, resource: VitalResource): Notification
+    fun build(context: Context, resources: Set<VitalResource>): Notification
 }

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncStarter.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncStarter.kt
@@ -1,0 +1,106 @@
+package io.tryvital.vitalhealthconnect.workers
+
+import android.content.Context
+import androidx.lifecycle.asFlow
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import io.tryvital.client.utils.VitalLogger
+import io.tryvital.vitalhealthconnect.SyncNotificationBuilder
+import io.tryvital.vitalhealthconnect.VitalHealthConnectManager
+import io.tryvital.vitalhealthconnect.model.VitalResource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.transformWhile
+import kotlin.random.Random
+
+data class ResourceSyncStarterInput(
+    val resources: Set<VitalResource>,
+) {
+    fun toData(): Data = Data.Builder().run {
+        putStringArray("resources", resources.map { it.toString() }.toTypedArray())
+        build()
+    }
+
+    companion object {
+        fun fromData(data: Data) = ResourceSyncStarterInput(
+            resources = data.getStringArray("resources")?.mapTo(mutableSetOf()) { VitalResource.valueOf(it) } ?: emptySet()
+        )
+    }
+}
+
+/**
+ * An umbrella worker which we use to spawn `ResourceSyncWorker`s.
+ *
+ * This ensures that we only need to start Foreground Service once at the beginning
+ * for all the requested [VitalResource], while the app is most likely still in the foreground.
+ *
+ * Android OS rejects [setForeground] when the app is in background.
+ */
+class ResourceSyncStarter(appContext: Context, workerParams: WorkerParameters) :
+    CoroutineWorker(appContext, workerParams) {
+
+    private val input: ResourceSyncStarterInput by lazy {
+        ResourceSyncStarterInput.fromData(inputData)
+    }
+
+    private val syncNotificationBuilder: SyncNotificationBuilder? by lazy {
+        VitalHealthConnectManager.getOrCreate(applicationContext).syncNotificationBuilder
+    }
+
+    override suspend fun doWork(): Result {
+        val logger = VitalLogger.getOrCreate()
+
+        logger.logI("ResourceSyncStarter begin")
+
+        syncNotificationBuilder?.run {
+            val notification = build(applicationContext, input.resources)
+            setForeground(
+                ForegroundInfo(VITAL_SYNC_NOTIFICATION_ID, notification)
+            )
+        }
+
+        for (resource in input.resources) {
+            val workRequest = OneTimeWorkRequestBuilder<ResourceSyncWorker>()
+                .setInputData(ResourceSyncWorkerInput(resource = resource).toData())
+                .addTag(resource.name)
+                .build()
+
+            val work = WorkManager.getInstance(applicationContext).beginUniqueWork(
+                "ResourceSyncWorker.${resource}",
+                ExistingWorkPolicy.REPLACE,
+                workRequest
+            )
+
+            work.workInfosLiveData.asFlow()
+                .mapNotNull { workInfos -> workInfos.firstOrNull { it.id == workRequest.id } }
+                .transformWhile { info ->
+                    emit(info)
+                    return@transformWhile when (info.state) {
+                        // Work is running; continue the observation
+                        WorkInfo.State.ENQUEUED, WorkInfo.State.RUNNING, WorkInfo.State.BLOCKED -> true
+                        // Work has ended; stop the observation
+                        WorkInfo.State.SUCCEEDED, WorkInfo.State.CANCELLED, WorkInfo.State.FAILED -> false
+                    }
+                }
+                .onStart { work.enqueue() }
+                .flowOn(Dispatchers.Main)
+                .collect {}
+
+            // Rate limit mitigation, ugh
+            delay(Random.nextLong(1, 15) * 100)
+        }
+
+        logger.logI("ResourceSyncStarter ends")
+
+        return Result.success()
+    }
+}

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncWorker.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncWorker.kt
@@ -33,6 +33,7 @@ import io.tryvital.vitalhealthconnect.records.RecordProcessor
 import io.tryvital.vitalhealthconnect.records.RecordReader
 import io.tryvital.vitalhealthconnect.records.RecordUploader
 import io.tryvital.vitalhealthconnect.records.VitalClientRecordUploader
+import kotlinx.coroutines.delay
 import java.time.Instant
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
@@ -87,9 +88,6 @@ class ResourceSyncWorker(appContext: Context, workerParams: WorkerParameters) :
 
     private val vitalClient: VitalClient by lazy {
         VitalClient.getOrCreate(applicationContext)
-    }
-    private val syncNotificationBuilder: SyncNotificationBuilder? by lazy {
-        VitalHealthConnectManager.getOrCreate(applicationContext).syncNotificationBuilder
     }
     private val sharedPreferences: SharedPreferences get() = vitalClient.sharedPreferences
     private val healthConnectClientProvider by lazy { HealthConnectClientProvider() }
@@ -151,13 +149,6 @@ class ResourceSyncWorker(appContext: Context, workerParams: WorkerParameters) :
             ?: initialState(timeZone)
 
         vitalLogger.logI("ResourceSyncWorker: starting for ${input.resource}; state = $state")
-
-        syncNotificationBuilder?.run {
-            val notification = build(applicationContext, input.resource)
-            setForeground(
-                ForegroundInfo(VITAL_SYNC_NOTIFICATION_ID, notification)
-            )
-        }
 
         when (state) {
             is ResourceSyncState.Historical -> historicalBackfill(state, timeZone)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 

--- a/app/src/main/java/io/tryvital/sample/VitalSyncNotificationBuilder.kt
+++ b/app/src/main/java/io/tryvital/sample/VitalSyncNotificationBuilder.kt
@@ -10,11 +10,11 @@ import io.tryvital.vitalhealthconnect.SyncNotificationBuilder
 import io.tryvital.vitalhealthconnect.model.VitalResource
 
 object VitalSyncNotificationBuilder: SyncNotificationBuilder {
-    override fun build(context: Context, resource: VitalResource): Notification {
+    override fun build(context: Context, resources: Set<VitalResource>): Notification {
         return NotificationCompat.Builder(context, createChannel(context))
             .setContentTitle("Vital Sync")
             .setTicker("Vital Sync")
-            .setContentText("$resource is being synchronized")
+            .setContentText("Syncing ${resources.map { it.toString() }.joinToString(", ")}")
             .setOngoing(true)
             .setSmallIcon(android.R.drawable.ic_popup_sync)
             .build()


### PR DESCRIPTION
Upon further testing, we cannot upgrade our worker to be a Foreground Service when the app has entered background.

This means ideally we should start the Foreground Service status once (when the app is in foreground), and have the status lasting until ALL the resources requested have run to completion or failure.

This PR introduced `ResourceSyncStarter` as such worker (that manages the individual resource workers).

* It accepts a `Set<VitalResource>`, i.e. resources that need to be synced, as input.

* It calls `setForeground` before any work begins.

* It then spawns a worker for a resource, and waits for its completion before moving onto the next one.

    * There is still room for optimisation as well, e.g., we should prioritise syncing historical stage first and then failed resources next (due to rate limit or network failure).

* It inserts a random delay to mitigate the Health Connect rate limit (seemingly queries per second... still exploring).


#### Notification example

![image](https://github.com/tryVital/vital-android/assets/11806295/fff4a5c7-57a1-43f6-b9d9-926ab98934b6)
(the icon spins btw) 
