### PR TITLE
VIT-4348: More proactive DeviceManager permission checking

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.8.10" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,7 @@
       <item index="0" class="java.lang.String" itemvalue="com.squareup.moshi.Json" />
     </list>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/Libre1Reader.kt
+++ b/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/Libre1Reader.kt
@@ -1,7 +1,9 @@
 package io.tryvital.vitaldevices.devices
 
 import android.app.Activity
+import android.content.pm.PackageManager.PERMISSION_GRANTED
 import io.tryvital.client.services.data.QuantitySamplePayload
+import io.tryvital.vitaldevices.PermissionMissing
 import io.tryvital.vitaldevices.devices.nfc.Glucose
 import io.tryvital.vitaldevices.devices.nfc.NFC
 import io.tryvital.vitaldevices.devices.nfc.Sensor
@@ -65,6 +67,10 @@ interface Libre1Reader {
 
 internal class Libre1ReaderImpl(private val activity: Activity): Libre1Reader {
     override suspend fun read(): Libre1Read {
+        if (activity.checkCallingOrSelfPermission(android.Manifest.permission.NFC) != PERMISSION_GRANTED) {
+            throw PermissionMissing(android.Manifest.permission.NFC)
+        }
+
         var nfc: NFC? = null
 
         val (sensor, glucose) = suspendCancellableCoroutine { continuation ->

--- a/app/src/main/java/io/tryvital/sample/ui/device/DeviceScreen.kt
+++ b/app/src/main/java/io/tryvital/sample/ui/device/DeviceScreen.kt
@@ -9,6 +9,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -20,6 +21,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -186,7 +188,7 @@ fun DeviceScreen(vitalDeviceManager: VitalDeviceManager, navController: NavHostC
                                 Text(text = scannedDevice.name)
                             },
                             trailingContent = {
-                                Row {
+                                Row(verticalAlignment = CenterVertically) {
                                     if (scannedDevice.canPair) {
                                         Button(onClick = {
                                             viewModel.pair(context, scannedDevice)
@@ -195,10 +197,35 @@ fun DeviceScreen(vitalDeviceManager: VitalDeviceManager, navController: NavHostC
                                         }
                                         Box(modifier = Modifier.width(4.dp))
                                     }
-                                    Button(onClick = {
-                                        viewModel.connect(context, context as ComponentActivity, scannedDevice)
-                                    }) {
-                                        Text("Read")
+
+                                    if (state.isReading) {
+                                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                                        Spacer(modifier = Modifier.width(4.dp))
+                                    }
+
+                                    Button(
+                                        onClick = {
+                                            if (state.isReading) {
+                                                viewModel.cancelRead()
+                                            } else {
+                                                viewModel.connect(
+                                                    context,
+                                                    context as ComponentActivity,
+                                                    scannedDevice
+                                                )
+                                            }
+                                        },
+                                        colors = if (state.isReading) {
+                                            ButtonDefaults.outlinedButtonColors()
+                                        } else {
+                                            ButtonDefaults.filledTonalButtonColors()
+                                        }
+                                    ) {
+                                        if (state.isReading) {
+                                            Text("Cancel")
+                                        } else {
+                                            Text("Read")
+                                        }
                                     }
                                 }
                             },


### PR DESCRIPTION
* Proactively check for BLE/NFC permissions and throw PermissionMissing when they are absent.

* Add a progress indicator and a Cancel button to the Device Example screen when a `read()` call is in progress.

