### PR TITLE
VIT-4414: VitalJWTAuth - VitalClient integration

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
     <list size="1">

--- a/VitalClient/src/main/java/io/tryvital/client/Configuration.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/Configuration.kt
@@ -1,17 +1,27 @@
 package io.tryvital.client
 
 import android.content.SharedPreferences
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 
 const val VITAL_ENCRYPTED_USER_ID_KEY: String = "userId"
 const val VITAL_ENCRYPTED_REGION_KEY = "region"
 const val VITAL_ENCRYPTED_ENVIRONMENT_KEY = "environment"
 const val VITAL_ENCRYPTED_API_KEY_KEY = "apiKey"
+const val VITAL_ENCRYPTED_AUTH_STRATEGY_KEY = "auth_strategy"
 
 internal interface ConfigurationReader {
     val userId: String?
-    val region: Region?
-    val environment: Environment?
-    val apiKey: String?
+    val authStrategy: VitalClientAuthStrategy?
+}
+
+internal sealed class VitalClientAuthStrategy {
+    abstract val environment: Environment
+    abstract val region: Region
+
+    data class JWT(override val environment: Environment, override val region: Region): VitalClientAuthStrategy()
+    data class APIKey(val apiKey: String, override val environment: Environment, override val region: Region): VitalClientAuthStrategy()
 }
 
 @JvmInline
@@ -19,22 +29,46 @@ internal value class SharedPreferencesConfigurationReader(
     private val sharedPreferences: SharedPreferences
 ): ConfigurationReader {
     override val userId: String? get() = sharedPreferences.getString(VITAL_ENCRYPTED_USER_ID_KEY, null)
-    override val region: Region?
-        get() = sharedPreferences.getString(VITAL_ENCRYPTED_REGION_KEY, null)
-            ?.let { Region.valueOf(it) }
-    override val environment: Environment?
-        get() = sharedPreferences.getString(
-            VITAL_ENCRYPTED_ENVIRONMENT_KEY,
-            null
-        )?.let { Environment.valueOf(it) }
-    override val apiKey: String? get() = sharedPreferences.getString(VITAL_ENCRYPTED_API_KEY_KEY, null)
+    override val authStrategy: VitalClientAuthStrategy?
+        get() {
+            val rawAuthStrategy =
+                sharedPreferences.getString(VITAL_ENCRYPTED_AUTH_STRATEGY_KEY, null)
+            if (rawAuthStrategy != null) {
+                return configurationMoshi.adapter(VitalClientAuthStrategy::class.java)
+                    .fromJson(rawAuthStrategy)!!
+            }
+
+            // Backward compatibility
+            val region = sharedPreferences.getString(VITAL_ENCRYPTED_REGION_KEY, null)
+                ?.let { Region.valueOf(it) }
+            val environment = sharedPreferences.getString(VITAL_ENCRYPTED_ENVIRONMENT_KEY, null)
+                ?.let { Environment.valueOf(it) }
+            val apiKey: String? = sharedPreferences.getString(VITAL_ENCRYPTED_API_KEY_KEY, null)
+
+            if (region != null && environment != null && apiKey != null) {
+                return VitalClientAuthStrategy.APIKey(apiKey, environment, region)
+            }
+
+            return null
+        }
 }
 
 internal data class StaticConfiguration(
-    override val region: Region? = null,
-    override val environment: Environment? = null,
-    override val apiKey: String? = null,
+    override val authStrategy: VitalClientAuthStrategy?,
     override val userId: String? = null,
 ): ConfigurationReader
 
 class VitalClientUnconfigured: Throwable("VitalClient has not been configured.")
+
+
+internal val configurationMoshi by lazy {
+    Moshi.Builder()
+        .add(
+            PolymorphicJsonAdapterFactory
+                .of(VitalClientAuthStrategy::class.java,"type")
+                .withSubtype(VitalClientAuthStrategy.JWT::class.java, "jwt")
+                .withSubtype(VitalClientAuthStrategy.APIKey::class.java, "apiKey")
+        )
+        .addLast(KotlinJsonAdapterFactory())
+        .build()
+}

--- a/VitalClient/src/main/java/io/tryvital/client/utils/ApiKeyInterceptor.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/utils/ApiKeyInterceptor.kt
@@ -1,14 +1,43 @@
 package io.tryvital.client.utils
 
 import io.tryvital.client.ConfigurationReader
+import io.tryvital.client.VitalClientAuthStrategy
 import io.tryvital.client.VitalClientUnconfigured
+import io.tryvital.client.jwt.AbstractVitalJWTAuth
+import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Response
 
-internal class ApiKeyInterceptor(private val configurationReader: ConfigurationReader): Interceptor {
+internal class ApiKeyInterceptor(
+    private val configurationReader: ConfigurationReader,
+    private val jwtAuth: AbstractVitalJWTAuth,
+): Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        val apiKey = configurationReader.apiKey ?: throw VitalClientUnconfigured()
-        val request = chain.request().newBuilder().addHeader("x-vital-api-key", apiKey).build()
-        return chain.proceed(request)
+        val authStrategy = configurationReader.authStrategy ?: throw VitalClientUnconfigured()
+
+        val request = when (authStrategy) {
+            is VitalClientAuthStrategy.APIKey -> {
+                chain.request().newBuilder().addHeader("x-vital-api-key", authStrategy.apiKey)
+                    .build()
+            }
+
+            is VitalClientAuthStrategy.JWT -> {
+                val token = runBlocking { jwtAuth.withAccessToken { it } }
+                chain.request().newBuilder().addHeader("authorization", "Bearer $token").build()
+            }
+        }
+
+        val response = chain.proceed(request)
+
+        return if (response.code == 401 && authStrategy is VitalClientAuthStrategy.JWT) {
+            val token = runBlocking {
+                jwtAuth.refreshToken()
+                jwtAuth.withAccessToken { it }
+            }
+            val retryRequest = chain.request().newBuilder().addHeader("authorization", "Bearer $token").build()
+            chain.proceed(retryRequest)
+        } else {
+            response
+        }
     }
 }

--- a/VitalClient/src/test/java/io/tryvital/client/ActivityServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/ActivityServiceTest.kt
@@ -19,11 +19,7 @@ class ActivityServiceTest {
     @Before
     fun setUp() {
         server = MockWebServer()
-        retrofit = Dependencies.createRetrofit(
-            server.url("").toString(),
-            Dependencies.createHttpClient(null, StaticConfiguration(apiKey = apiKey)),
-            Dependencies.createMoshi()
-        )
+        retrofit = server.createTestRetrofit()
     }
 
     @After

--- a/VitalClient/src/test/java/io/tryvital/client/BodyServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/BodyServiceTest.kt
@@ -20,12 +20,7 @@ class BodyServiceTest {
     @Before
     fun setUp() {
         server = MockWebServer()
-
-        retrofit = Dependencies.createRetrofit(
-            server.url("").toString(),
-            Dependencies.createHttpClient(null, StaticConfiguration(apiKey = apiKey)),
-            Dependencies.createMoshi()
-        )
+        retrofit = server.createTestRetrofit()
     }
 
     @After

--- a/VitalClient/src/test/java/io/tryvital/client/LinkServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/LinkServiceTest.kt
@@ -19,12 +19,7 @@ class LinkServiceTest {
     @Before
     fun setUp() {
         server = MockWebServer()
-
-        retrofit = Dependencies.createRetrofit(
-            server.url("").toString(),
-            Dependencies.createHttpClient(null, StaticConfiguration(apiKey = apiKey)),
-            Dependencies.createMoshi()
-        )
+        retrofit = server.createTestRetrofit()
     }
 
     @After

--- a/VitalClient/src/test/java/io/tryvital/client/MockVitalJWTAuth.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/MockVitalJWTAuth.kt
@@ -1,0 +1,13 @@
+package io.tryvital.client
+
+import io.tryvital.client.jwt.AbstractVitalJWTAuth
+
+class MockVitalJWTAuth: AbstractVitalJWTAuth {
+    override suspend fun <Result> withAccessToken(action: suspend (String) -> Result): Result {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun refreshToken() {
+        TODO("Not yet implemented")
+    }
+}

--- a/VitalClient/src/test/java/io/tryvital/client/ProfileServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/ProfileServiceTest.kt
@@ -19,12 +19,7 @@ class ProfileServiceTest {
     @Before
     fun setUp() {
         server = MockWebServer()
-
-        retrofit = Dependencies.createRetrofit(
-            server.url("").toString(),
-            Dependencies.createHttpClient(null, StaticConfiguration(apiKey = apiKey)),
-            Dependencies.createMoshi()
-        )
+        retrofit = server.createTestRetrofit()
     }
 
     @After

--- a/VitalClient/src/test/java/io/tryvital/client/SleepServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/SleepServiceTest.kt
@@ -21,12 +21,7 @@ class SleepServiceTest {
     @Before
     fun setUp() {
         server = MockWebServer()
-
-        retrofit = Dependencies.createRetrofit(
-            server.url("").toString(),
-            Dependencies.createHttpClient(null, StaticConfiguration(apiKey = apiKey)),
-            Dependencies.createMoshi()
-        )
+        retrofit = server.createTestRetrofit()
     }
 
     @After

--- a/VitalClient/src/test/java/io/tryvital/client/SummaryServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/SummaryServiceTest.kt
@@ -20,12 +20,7 @@ class SummaryServiceTest {
     @Before
     fun setUp() {
         server = MockWebServer()
-
-        retrofit = Dependencies.createRetrofit(
-            server.url("").toString(),
-            Dependencies.createHttpClient(null, StaticConfiguration(apiKey = apiKey)),
-            Dependencies.createMoshi()
-        )
+        retrofit = server.createTestRetrofit()
     }
 
     @After

--- a/VitalClient/src/test/java/io/tryvital/client/UserServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/UserServiceTest.kt
@@ -23,12 +23,7 @@ class UserServiceTest {
     @Before
     fun setUp() {
         server = MockWebServer()
-
-        retrofit = Dependencies.createRetrofit(
-            server.url("").toString(),
-            Dependencies.createHttpClient(null, StaticConfiguration(apiKey = apiKey)),
-            Dependencies.createMoshi()
-        )
+        retrofit = server.createTestRetrofit()
     }
 
     @After

--- a/VitalClient/src/test/java/io/tryvital/client/VitalsServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/VitalsServiceTest.kt
@@ -21,12 +21,7 @@ class VitalsServiceTest {
     @Before
     fun setUp() {
         server = MockWebServer()
-
-        retrofit = Dependencies.createRetrofit(
-            server.url("").toString(),
-            Dependencies.createHttpClient(null, StaticConfiguration(apiKey = apiKey)),
-            Dependencies.createMoshi()
-        )
+        retrofit = server.createTestRetrofit()
     }
 
     @After

--- a/VitalClient/src/test/java/io/tryvital/client/WorkoutServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/WorkoutServiceTest.kt
@@ -19,12 +19,7 @@ class WorkoutServiceTest {
     @Before
     fun setUp() {
         server = MockWebServer()
-
-        retrofit = Dependencies.createRetrofit(
-            server.url("").toString(),
-            Dependencies.createHttpClient(null, StaticConfiguration(apiKey = apiKey)),
-            Dependencies.createMoshi()
-        )
+        retrofit = server.createTestRetrofit()
     }
 
     @After

--- a/VitalClient/src/test/java/io/tryvital/client/testCommon.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/testCommon.kt
@@ -1,0 +1,23 @@
+package io.tryvital.client
+
+import io.tryvital.client.dependencies.Dependencies
+import okhttp3.mockwebserver.MockWebServer
+import retrofit2.Retrofit
+
+fun MockWebServer.createTestRetrofit(): Retrofit {
+    return Dependencies.createRetrofit(
+        this.url("").toString(),
+        Dependencies.createHttpClient(
+            null,
+            StaticConfiguration(
+                authStrategy = VitalClientAuthStrategy.APIKey(
+                    environment = Environment.Dev,
+                    region = Region.US,
+                    apiKey = "fake-api-key",
+                )
+            ),
+            MockVitalJWTAuth()
+        ),
+        Dependencies.createMoshi()
+    )
+}

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
@@ -166,7 +166,7 @@ class VitalHealthConnectManager private constructor(
         numberOfDaysToBackFill: Int = 30,
         syncNotificationBuilder: SyncNotificationBuilder? = null,
     ) {
-        if (!vitalClient.isConfigured) {
+        if (VitalClient.Status.Configured !in VitalClient.status) {
             throw IllegalStateException("VitalClient has not been configured.")
         }
 
@@ -179,7 +179,7 @@ class VitalHealthConnectManager private constructor(
             .putInt(UnSecurePrefKeys.numberOfDaysToBackFillKey, numberOfDaysToBackFill)
             .commit()
 
-        if (vitalClient.hasUserId() && isAvailable(context) == HealthConnectAvailability.Installed) {
+        if (VitalClient.Status.SignedIn in VitalClient.status && isAvailable(context) == HealthConnectAvailability.Installed) {
             vitalLogger.logI("Configuration set, starting sync")
             taskScope.launch {
                 syncData(healthResources)

--- a/app/src/main/java/io/tryvital/sample/VitalApp.kt
+++ b/app/src/main/java/io/tryvital/sample/VitalApp.kt
@@ -15,7 +15,7 @@ val environment = Environment.Dev
 class VitalApp : Application() {
     val client by lazy {
         VitalClient.getOrCreate(applicationContext).apply {
-            configure(region, environment, apiKey)
+            VitalClient.configure(applicationContext, region, environment, apiKey)
         }
     }
 
@@ -24,7 +24,7 @@ class VitalApp : Application() {
     }
 
     val vitalHealthConnectManager by lazy {
-        check(this.client.isConfigured)
+        check(VitalClient.Status.Configured in VitalClient.status)
         VitalHealthConnectManager.getOrCreate(this).apply {
             configureHealthConnectClient(
                 syncNotificationBuilder = VitalSyncNotificationBuilder

--- a/app/src/main/java/io/tryvital/sample/ui/healthconnect/HealthConnectViewModel.kt
+++ b/app/src/main/java/io/tryvital/sample/ui/healthconnect/HealthConnectViewModel.kt
@@ -26,7 +26,7 @@ class HealthConnectViewModel(
     private val userRepository: UserRepository
 ) : ViewModel() {
     private val isCurrentSDKUser
-        get() = userRepository.selectedUser!!.userId == vitalClient.currentUserId
+        get() = userRepository.selectedUser!!.userId == VitalClient.currentUserId
 
     private val viewModelState =
         MutableStateFlow(HealthConnectViewModelState(


### PR DESCRIPTION
Integrating VitalJWTAuth into VitalClient with the same approach as the integration in the iOS SDK.

Introduced `VitalClient.configure()`, `VitalClient.status` and `VitalClient.currentUserId` to mirror the iOS SDK.

Introduced `VitalClient.signIn` for sign-ins using Vital Sign-In Tokens + configuring the SDK into User JWT mode.


