### PR TITLE
VIT-4470: Android example app: Scaffolding for Settings screen

### DIFF
--- a/app/src/main/java/io/tryvital/sample/MainActivity.kt
+++ b/app/src/main/java/io/tryvital/sample/MainActivity.kt
@@ -3,17 +3,40 @@ package io.tryvital.sample
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bluetooth
+import androidx.compose.material.icons.filled.List
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemColors
+import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import io.tryvital.client.utils.VitalLogger
 import io.tryvital.sample.ui.device.DeviceScreen
 import io.tryvital.sample.ui.devices.DevicesScreen
 import io.tryvital.sample.ui.healthconnect.HealthConnectScreen
+import io.tryvital.sample.ui.settings.SettingsScreen
 import io.tryvital.sample.ui.theme.VitalSampleTheme
 import io.tryvital.sample.ui.users.UsersScreen
 
 class MainActivity : ComponentActivity() {
+    @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val vitalApp = application as VitalApp
@@ -25,37 +48,71 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             val navController = rememberNavController()
+            val backStackEntry = navController.currentBackStackEntryAsState()
+            val currentRoute = backStackEntry.value?.destination?.route
+
+            @Composable
+            fun RowScope.makeBarItem(label: String, vector: ImageVector, screen: Screen) {
+                NavigationBarItem(
+                    label = { Text(label) },
+                    icon = {
+                        Icon(
+                            imageVector = vector,
+                            contentDescription = label,
+                            modifier = Modifier.size(24.dp),
+                        )
+                    },
+                    onClick = { navController.navigate(screen.route) },
+                    selected = currentRoute == screen.route,
+                )
+            }
 
             VitalSampleTheme {
-                NavHost(
-                    navController = navController,
-                    startDestination = Screen.Users.route
-                ) {
-                    composable(Screen.Users.route) {
-                        UsersScreen(
-                            client,
-                            navController,
-                            userRepository
-                        )
+                Scaffold(
+                    bottomBar = {
+                        NavigationBar {
+                            makeBarItem("Users", Icons.Default.List, Screen.Users)
+                            makeBarItem("Devices", Icons.Default.Bluetooth, Screen.Devices)
+                            makeBarItem("Settings", Icons.Default.Settings, Screen.Settings)
+                        }
                     }
-                    composable(Screen.HealthConnect.route) {
-                        HealthConnectScreen(
-                            client,
-                            vitalHealthConnectManager,
-                            userRepository,
-                            navController,
-                        )
-                    }
-                    composable(Screen.Device.route + "{deviceId}") {
-                        DeviceScreen(
-                            vitalDeviceManager,
-                            navController,
-                        )
-                    }
-                    composable(Screen.Devices.route) {
-                        DevicesScreen(
-                            navController,
-                        )
+                ) { padding ->
+                    NavHost(
+                        modifier = Modifier.padding(padding),
+                        navController = navController,
+                        startDestination = Screen.Users.route,
+                    ) {
+                        composable(Screen.Users.route) {
+                            UsersScreen(
+                                client,
+                                navController,
+                                userRepository
+                            )
+                        }
+                        composable(Screen.HealthConnect.route) {
+                            HealthConnectScreen(
+                                client,
+                                vitalHealthConnectManager,
+                                userRepository,
+                                navController,
+                            )
+                        }
+                        composable(Screen.Device.route + "{deviceId}") {
+                            DeviceScreen(
+                                vitalDeviceManager,
+                                navController,
+                            )
+                        }
+                        composable(Screen.Devices.route) {
+                            DevicesScreen(
+                                navController,
+                            )
+                        }
+                        composable(Screen.Settings.route) {
+                            SettingsScreen(
+                                navController,
+                            )
+                        }
                     }
                 }
             }
@@ -68,4 +125,5 @@ sealed class Screen(val route: String) {
     object HealthConnect : Screen("healthConnect")
     object Devices : Screen("devices")
     object Device : Screen("device")
+    object Settings : Screen("settings")
 }

--- a/app/src/main/java/io/tryvital/sample/ui/devices/DevicesScreen.kt
+++ b/app/src/main/java/io/tryvital/sample/ui/devices/DevicesScreen.kt
@@ -37,13 +37,7 @@ fun DevicesScreen(navController: NavHostController) {
     Scaffold(topBar = {
         TopAppBar(title = { Text("Supported devices") },
             colors = TopAppBarDefaults.smallTopAppBarColors(containerColor = Color(0xFFE0E0E0)),
-            navigationIcon = {
-                IconButton(onClick = {
-                    navController.popBackStack()
-                }) {
-                    Icon(Icons.Filled.ArrowBack, "backIcon")
-                }
-            })
+        )
     }, content = { padding ->
         Column(
             modifier = Modifier

--- a/app/src/main/java/io/tryvital/sample/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/tryvital/sample/ui/settings/SettingsScreen.kt
@@ -1,0 +1,40 @@
+package io.tryvital.sample.ui.settings
+
+import android.content.pm.PackageManager.*
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavHostController
+import coil.compose.rememberAsyncImagePainter
+import io.tryvital.sample.Screen
+import io.tryvital.vitaldevices.Brand
+import io.tryvital.vitaldevices.DeviceModel
+import io.tryvital.vitaldevices.Kind
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+fun SettingsScreen(navController: NavHostController) {
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("Settings") },
+                colors = TopAppBarDefaults.smallTopAppBarColors(containerColor = Color(0xFFE0E0E0)),
+            )
+        }
+    ) { padding ->
+        val empty = padding
+    }
+}

--- a/app/src/main/java/io/tryvital/sample/ui/users/UsersScreen.kt
+++ b/app/src/main/java/io/tryvital/sample/ui/users/UsersScreen.kt
@@ -69,13 +69,6 @@ fun UsersScreen(
                 title = { Text("Vital sample") },
                 actions = {
                     IconAction(
-                        painter = rememberVectorPainter(image = Icons.Default.Bluetooth),
-                        description = "Add user",
-                        onClick = {
-                            navController.navigate(Screen.Devices.route)
-                        }
-                    )
-                    IconAction(
                         painter = rememberVectorPainter(image = Icons.Default.Person),
                         description = "Add user",
                         onClick = {


### PR DESCRIPTION
* Switch to a tabbed setup to mirror iOS Demo app. (Users / Devices / Settings)

* Create scaffolding for Settings screen.


