### PR TITLE
VIT-4470: Mark some UserService methods as deprecated

### DIFF
--- a/VitalClient/src/main/java/io/tryvital/client/services/ControlPlaneService.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/ControlPlaneService.kt
@@ -18,6 +18,9 @@ interface ControlPlaneService {
     @DELETE("user/{user_id}")
     suspend fun deleteUser(@Path("user_id") userId: String): DeleteUserResponse
 
+    @GET("user/resolve/{client_user_id}")
+    suspend fun resolveUser(@Path("client_user_id") clientUserId: String): User
+
     companion object {
         fun create(retrofit: Retrofit): ControlPlaneService {
             return retrofit.create(ControlPlaneService::class.java)

--- a/VitalClient/src/main/java/io/tryvital/client/services/UserService.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/UserService.kt
@@ -6,18 +6,22 @@ import retrofit2.http.*
 
 @Suppress("unused")
 interface UserService {
+    @Deprecated(message = "Moved to ControlPlaneService, which can be instantiated with VitalClient.Companion.controlPlane(...).")
     @GET("user/")
     suspend fun getAll(): GetAllUsersResponse
 
     @GET("user/{user_id}")
     suspend fun getUser(@Path("user_id") userId: String): User
 
+    @Deprecated(message = "Moved to ControlPlaneService, which can be instantiated with VitalClient.Companion.controlPlane(...).")
     @POST("user")
     suspend fun createUser(@Body request: CreateUserRequest): CreateUserResponse
 
+    @Deprecated(message = "Moved to ControlPlaneService, which can be instantiated with VitalClient.Companion.controlPlane(...).")
     @DELETE("user/{user_id}")
     suspend fun deleteUser(@Path("user_id") userId: String): DeleteUserResponse
 
+    @Deprecated(message = "Moved to ControlPlaneService, which can be instantiated with VitalClient.Companion.controlPlane(...).")
     @GET("user/resolve/{client_user_id}")
     suspend fun resolveUser(@Path("client_user_id") clientUserId: String): User
 


### PR DESCRIPTION
These calls are not compatible with User JWT mode, and they are now exposed separately in a new location aka `ControlPlaneService` (created by `VitalClient.Companion.controlPlane`) that does not require SDK configuration.

