### PR TITLE
VIT-4551: Introduce VitalClient.linkOAuthProvider

### DIFF
--- a/VitalClient/src/main/java/io/tryvital/client/services/VitalClientExtension.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/VitalClientExtension.kt
@@ -5,9 +5,35 @@ import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
 import io.tryvital.client.VitalClient
 import io.tryvital.client.services.data.CreateLinkRequest
+import io.tryvital.client.services.data.OAuthProviderSlug
 import io.tryvital.client.services.data.User
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.IOException
 
+suspend fun VitalClient.linkOAuthProvider(
+    context: Context,
+    userId: String,
+    provider: OAuthProviderSlug,
+    callback: String,
+    customizeTabs: (CustomTabsIntent.Builder) -> CustomTabsIntent.Builder = { it }
+) {
+    val token = linkService
+        .createLink(CreateLinkRequest(userId, provider.toString(), callback))
+
+    val oauth = linkService.oauthProvider(
+        provider = provider.toString(),
+        linkToken = token.linkToken!!,
+    )
+
+    withContext(Dispatchers.Main) {
+        val builder = CustomTabsIntent.Builder().let(customizeTabs)
+        val customTabsIntent = builder.build()
+        customTabsIntent.launchUrl(context, Uri.parse(oauth.oauthUrl!!))
+    }
+}
+
+@Deprecated(message = "Use `linkOAuthProvider` instead")
 suspend fun VitalClient.linkUserWithOauthProvider(
     context: Context,
     user: User,

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/ProviderSlug.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/ProviderSlug.kt
@@ -32,6 +32,33 @@ enum class ManualProviderSlug {
 }
 
 @JsonClass(generateAdapter = false)
+enum class OAuthProviderSlug {
+    // Enum names here should match ProviderSlug.
+    @Json(name = "fitbit") Fitbit,
+    @Json(name = "oura") Oura,
+    @Json(name = "garmin") Garmin,
+    @Json(name = "google_fit") GoogleFit,
+    @Json(name = "strava") Strava,
+    @Json(name = "wahoo") Wahoo,
+    @Json(name = "withings") Withings,
+    @Json(name = "ihealth") IHealth,
+    @Json(name = "dexcom_v3") DexcomV3,
+    @Json(name = "polar") Polar,
+    @Json(name = "cronometer") Cronometer;
+
+    // Use the Json name also when converting to string.
+    // This is intended for Retrofit request parameter serialization.
+    override fun toString() = getJsonName(this)
+
+    fun toProviderSlug() = ProviderSlug.valueOf(name)
+
+    companion object {
+        val jsonAdapter: EnumJsonAdapter<OAuthProviderSlug>
+            get() = EnumJsonAdapter.create(OAuthProviderSlug::class.java)
+    }
+}
+
+@JsonClass(generateAdapter = false)
 enum class ProviderSlug {
     Unrecognized,
 
@@ -54,6 +81,9 @@ enum class ProviderSlug {
     @Json(name = "hammerhead") Hammerhead,
     @Json(name = "dexcom") Dexcom,
     @Json(name = "my_fitness_pal") MyFitnessPal,
+    @Json(name = "dexcom_v3") DexcomV3,
+    @Json(name = "polar") Polar,
+    @Json(name = "cronometer") Cronometer,
 
     // Manual
     @Json(name = "beurer_ble") BeurerBLE,

--- a/app/src/main/java/io/tryvital/sample/ui/users/UsersViewModel.kt
+++ b/app/src/main/java/io/tryvital/sample/ui/users/UsersViewModel.kt
@@ -6,7 +6,9 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import io.tryvital.client.VitalClient
 import io.tryvital.client.services.data.CreateUserRequest
+import io.tryvital.client.services.data.OAuthProviderSlug
 import io.tryvital.client.services.data.User
+import io.tryvital.client.services.linkOAuthProvider
 import io.tryvital.client.services.linkUserWithOauthProvider
 import io.tryvital.client.utils.VitalLogger
 import io.tryvital.sample.AppSettings
@@ -108,12 +110,16 @@ class UsersViewModel(
                 return@launch
             }
 
-            VitalClient.getOrCreate(context).linkUserWithOauthProvider(
-                context,
-                user,
-                "strava",
-                "vitalexample://callback"
-            )
+            try {
+                VitalClient.getOrCreate(context).linkOAuthProvider(
+                    context,
+                    user.userId,
+                    OAuthProviderSlug.Fitbit,
+                    "vitalexample://callback"
+                )
+            } catch (e: Throwable) {
+                setError(e)
+            }
         }
     }
 


### PR DESCRIPTION
1. Add typed OAuthProviderSlug

2. Introduce `linkOAuthProvider` to replace `linkUserWithOauthProvider`. The newer version no longer pretends to have caught all exceptions and return a `Result<Boolean>`. All exceptions are left to the caller to decide on the desirable way of handling.



