### PR TITLE
VIT-5527: Android SDK Level 34 fixes

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
     <list size="1">

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/VitalResource.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/VitalResource.kt
@@ -121,7 +121,6 @@ fun VitalResource.recordTypeDependencies(): List<KClass<out Record>> = when (thi
     VitalResource.Profile -> listOf(HeightRecord::class)
     VitalResource.Sleep -> listOf(
         SleepSessionRecord::class,
-        SleepStageRecord::class,
         HeartRateRecord::class,
         HeartRateVariabilityRmssdRecord::class,
         RespiratoryRateRecord::class,
@@ -141,7 +140,7 @@ fun VitalResource.recordTypeDependencies(): List<KClass<out Record>> = when (thi
  * This is a subset of [recordTypeDependencies]. Some VitalResources do not need to observe all the
  * record type they read.
  *
- * For example, Sleep only needs to observe SleepSessionRecord and SleepStageRecord changes, while
+ * For example, Sleep only needs to observe SleepSessionRecord changes, while
  * heart rate and other related data during the session can be read on demand as we compute the API
  * payload, on the assumption that these data should have been readily available in the Health
  * Connect data store.
@@ -161,7 +160,7 @@ fun VitalResource.recordTypeChangesToTriggerSync(): List<KClass<out Record>> = w
     VitalResource.HeartRate -> listOf(HeartRateRecord::class)
     VitalResource.HeartRateVariability -> listOf(HeartRateVariabilityRmssdRecord::class)
     VitalResource.Profile -> listOf(HeightRecord::class)
-    VitalResource.Sleep -> listOf(SleepSessionRecord::class, SleepStageRecord::class)
+    VitalResource.Sleep -> listOf(SleepSessionRecord::class)
     VitalResource.Workout -> listOf(ExerciseSessionRecord::class)
 
     VitalResource.ActiveEnergyBurned, VitalResource.BasalEnergyBurned, VitalResource.Steps ->

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordProcessor.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordProcessor.kt
@@ -18,7 +18,6 @@ import androidx.health.connect.client.records.Record
 import androidx.health.connect.client.records.RespiratoryRateRecord
 import androidx.health.connect.client.records.RestingHeartRateRecord
 import androidx.health.connect.client.records.SleepSessionRecord
-import androidx.health.connect.client.records.SleepStageRecord
 import androidx.health.connect.client.records.StepsRecord
 import androidx.health.connect.client.records.Vo2MaxRecord
 import androidx.health.connect.client.records.WeightRecord
@@ -324,7 +323,7 @@ internal class HealthConnectRecordProcessor(
                     fallbackDeviceModel
                 ),
                 stages = SleepStages(
-                    awakeSleepSamples = sleepSession.stages.filter { it.stage == SleepStageRecord.STAGE_TYPE_AWAKE }
+                    awakeSleepSamples = sleepSession.stages.filter { it.stage == SleepSessionRecord.STAGE_TYPE_AWAKE }
                         .map { sleepStage ->
                             QuantitySample(
                                 value = SleepStage.Awake.id.toDouble(),
@@ -335,7 +334,7 @@ internal class HealthConnectRecordProcessor(
                                 deviceModel = fallbackDeviceModel,
                             )
                         },
-                    deepSleepSamples = sleepSession.stages.filter { it.stage == SleepStageRecord.STAGE_TYPE_DEEP }
+                    deepSleepSamples = sleepSession.stages.filter { it.stage == SleepSessionRecord.STAGE_TYPE_DEEP }
                         .map { sleepStage ->
                             QuantitySample(
                                 value = SleepStage.Deep.id.toDouble(),
@@ -346,7 +345,7 @@ internal class HealthConnectRecordProcessor(
                                 deviceModel = fallbackDeviceModel,
                             )
                         },
-                    lightSleepSamples = sleepSession.stages.filter { it.stage == SleepStageRecord.STAGE_TYPE_LIGHT }
+                    lightSleepSamples = sleepSession.stages.filter { it.stage == SleepSessionRecord.STAGE_TYPE_LIGHT }
                         .map { sleepStage ->
                             QuantitySample(
                                 value = SleepStage.Light.id.toDouble(),
@@ -357,7 +356,7 @@ internal class HealthConnectRecordProcessor(
                                 deviceModel = fallbackDeviceModel,
                             )
                         },
-                    remSleepSamples = sleepSession.stages.filter { it.stage == SleepStageRecord.STAGE_TYPE_REM }
+                    remSleepSamples = sleepSession.stages.filter { it.stage == SleepSessionRecord.STAGE_TYPE_REM }
                         .map { sleepStage ->
                             QuantitySample(
                                 value = SleepStage.Rem.id.toDouble(),
@@ -368,7 +367,7 @@ internal class HealthConnectRecordProcessor(
                                 deviceModel = fallbackDeviceModel,
                             )
                         },
-                    unknownSleepSamples = sleepSession.stages.filter { it.stage == SleepStageRecord.STAGE_TYPE_UNKNOWN }
+                    unknownSleepSamples = sleepSession.stages.filter { it.stage == SleepSessionRecord.STAGE_TYPE_UNKNOWN }
                         .map { sleepStage ->
                             QuantitySample(
                                 value = SleepStage.Unknown.id.toDouble(),
@@ -379,7 +378,7 @@ internal class HealthConnectRecordProcessor(
                                 deviceModel = fallbackDeviceModel,
                             )
                         },
-                    outOfBedSleepSamples = sleepSession.stages.filter { it.stage == SleepStageRecord.STAGE_TYPE_OUT_OF_BED }
+                    outOfBedSleepSamples = sleepSession.stages.filter { it.stage == SleepSessionRecord.STAGE_TYPE_OUT_OF_BED }
                         .map { sleepStage ->
                             QuantitySample(
                                 value = SleepStage.OutOfBed.id.toDouble(),

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordReader.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordReader.kt
@@ -18,7 +18,6 @@ import androidx.health.connect.client.records.Record
 import androidx.health.connect.client.records.RespiratoryRateRecord
 import androidx.health.connect.client.records.RestingHeartRateRecord
 import androidx.health.connect.client.records.SleepSessionRecord
-import androidx.health.connect.client.records.SleepStageRecord
 import androidx.health.connect.client.records.StepsRecord
 import androidx.health.connect.client.records.Vo2MaxRecord
 import androidx.health.connect.client.records.WeightRecord
@@ -73,11 +72,6 @@ interface RecordReader {
         startTime: Instant,
         endTime: Instant
     ): List<SleepSessionRecord>
-
-    suspend fun readSleepStages(
-        startTime: Instant,
-        endTime: Instant
-    ): List<SleepStageRecord>
 
     suspend fun readOxygenSaturation(
         startTime: Instant,
@@ -174,11 +168,6 @@ internal class HealthConnectRecordReader(
     override suspend fun readSleepSession(
         startTime: Instant, endTime: Instant
     ): List<SleepSessionRecord> = readRecords(startTime, endTime)
-
-    override suspend fun readSleepStages(
-        startTime: Instant,
-        endTime: Instant
-    ): List<SleepStageRecord> = readRecords(startTime, endTime)
 
     override suspend fun readOxygenSaturation(
         startTime: Instant, endTime: Instant

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncStarter.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncStarter.kt
@@ -1,6 +1,7 @@
 package io.tryvital.vitalhealthconnect.workers
 
 import android.content.Context
+import android.os.Build
 import androidx.lifecycle.asFlow
 import androidx.work.CoroutineWorker
 import androidx.work.Data
@@ -63,9 +64,20 @@ class ResourceSyncStarter(appContext: Context, workerParams: WorkerParameters) :
 
         syncNotificationBuilder?.run {
             val notification = build(applicationContext, input.resources)
-            setForeground(
-                ForegroundInfo(VITAL_SYNC_NOTIFICATION_ID, notification)
-            )
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                setForeground(
+                    ForegroundInfo(
+                        VITAL_SYNC_NOTIFICATION_ID,
+                        notification,
+                        android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE,
+                    )
+                )
+            } else {
+                setForeground(
+                    ForegroundInfo(VITAL_SYNC_NOTIFICATION_ID, notification)
+                )
+            }
         }
 
         for (resource in input.resources) {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,6 +81,7 @@ dependencies {
     implementation "androidx.activity:activity-compose:$activity_compose"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_runtime"
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycle_viewmodel_compose"
+    implementation "androidx.work:work-runtime:2.3.1"
     implementation "androidx.health.connect:connect-client:$health_connect"
     implementation "io.coil-kt:coil-compose:${coil_compose}"
     implementation "androidx.startup:startup-runtime:1.1.1"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,10 @@
         android:name="android.permission.BLUETOOTH_ADMIN"
         android:maxSdkVersion="30" />
 
+    <uses-permission
+        android:name="android.permission.FOREGROUND_SERVICE"
+    />
+
     <!-- BEGIN: Health Connect permissions -->
     <uses-permission android:name="android.permission.health.READ_ACTIVE_CALORIES_BURNED" />
     <uses-permission android:name="android.permission.health.READ_BASAL_METABOLIC_RATE" />
@@ -85,11 +89,6 @@
                     android:path="/callback"
                     android:scheme="vitalexample" />
             </intent-filter>
-
-            <!-- TODO create a rational page for the privacy policy-->
-            <intent-filter>
-                <action android:name="androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE" />
-            </intent-filter>
         </activity>
 
         <provider
@@ -101,5 +100,40 @@
                 android:value="androidx.startup" />
         </provider>
 
+        <!-- BEGIN: Mandatory for Health Connect permission flow -->
+        <activity
+            android:name=".PermissionsRationaleActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE" />
+            </intent-filter>
+        </activity>
+
+        <!-- For versions starting Android 14, create an activity alias to show the rationale
+             of Health Connect permissions once users click the privacy policy link. -->
+        <activity-alias
+            android:name="ViewPermissionUsageActivity"
+            android:exported="true"
+            android:targetActivity=".PermissionsRationaleActivity"
+            android:permission="android.permission.START_VIEW_PERMISSION_USAGE">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW_PERMISSION_USAGE" />
+                <category android:name="android.intent.category.HEALTH_PERMISSIONS" />
+            </intent-filter>
+        </activity-alias>
+        <!-- END: Mandatory for Health Connect permission flow -->
+
+        <!-- BEGIN: Mandatory for running Health Connect as foreground service on Android 14+ -->
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="shortService"
+            android:exported="false">
+        </service>
+        <!-- END: Mandatory for running Health Connect as foreground service on Android 14+ -->
+
     </application>
+
+    <queries>
+        <package android:name="com.google.android.apps.healthdata" />
+    </queries>
 </manifest>

--- a/app/src/main/java/io/tryvital/sample/PermissionsRationaleActivity.kt
+++ b/app/src/main/java/io/tryvital/sample/PermissionsRationaleActivity.kt
@@ -1,0 +1,6 @@
+package io.tryvital.sample
+
+import androidx.activity.ComponentActivity
+
+class PermissionsRationaleActivity : ComponentActivity()  {
+}


### PR DESCRIPTION
Adapt the "Run sync as foreground service" feature to Android SDK Level 34 new restrictions on Foregorund Services.

Remove SleepStageRecord usage completely, since it is unsupported on Level 34+.
