### PR TITLE
CS1-95: Android: Migrate serialization from reflection to codegen

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
     <list size="1">

--- a/VitalClient/build.gradle
+++ b/VitalClient/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'com.google.devtools.ksp' version "$ksp"
 }
 
 android {
@@ -41,21 +42,22 @@ android {
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
         kotlinOptions {
             freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+            jvmTarget = JavaVersion.VERSION_1_8.toString()
         }
     }
 }
 
 dependencies {
+    ksp "com.squareup.moshi:moshi-kotlin-codegen:$moshi"
+
     implementation "androidx.browser:browser:$browser"
     implementation "androidx.security:security-crypto:$security_crypto"
 
-    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinx_coroutines"
 
     implementation "com.squareup.retrofit2:retrofit:$retrofit"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofit"
     implementation "com.squareup.moshi:moshi:$moshi"
-    implementation "com.squareup.moshi:moshi-kotlin:$moshi"
     implementation "com.squareup.moshi:moshi-adapters:$moshi"
     implementation "com.squareup.okhttp3:okhttp:$okhttp"
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttp"

--- a/VitalClient/consumer-rules.pro
+++ b/VitalClient/consumer-rules.pro
@@ -1,6 +1,3 @@
-# VitalCore SDK reflective models
--keep class io.tryvital.client.** { *; }
-
 # OkHttp 4.x workaround
 -dontwarn org.bouncycastle.jsse.BCSSLParameters
 -dontwarn org.bouncycastle.jsse.BCSSLSocket

--- a/VitalClient/src/main/java/io/tryvital/client/Configuration.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/Configuration.kt
@@ -1,9 +1,9 @@
 package io.tryvital.client
 
 import android.content.SharedPreferences
+import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 
 const val VITAL_ENCRYPTED_USER_ID_KEY: String = "userId"
 const val VITAL_ENCRYPTED_REGION_KEY = "region"
@@ -16,11 +16,14 @@ internal interface ConfigurationReader {
     val authStrategy: VitalClientAuthStrategy?
 }
 
+@JsonClass(generateAdapter = false)
 internal sealed class VitalClientAuthStrategy {
     abstract val environment: Environment
     abstract val region: Region
 
+    @JsonClass(generateAdapter = true)
     data class JWT(override val environment: Environment, override val region: Region): VitalClientAuthStrategy()
+    @JsonClass(generateAdapter = true)
     data class APIKey(val apiKey: String, override val environment: Environment, override val region: Region): VitalClientAuthStrategy()
 }
 
@@ -69,6 +72,5 @@ internal val configurationMoshi by lazy {
                 .withSubtype(VitalClientAuthStrategy.JWT::class.java, "jwt")
                 .withSubtype(VitalClientAuthStrategy.APIKey::class.java, "apiKey")
         )
-        .addLast(KotlinJsonAdapterFactory())
         .build()
 }

--- a/VitalClient/src/main/java/io/tryvital/client/Environment.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/Environment.kt
@@ -1,5 +1,8 @@
 package io.tryvital.client
 
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = false)
 enum class Environment {
     Dev, Sandbox, Production
 }

--- a/VitalClient/src/main/java/io/tryvital/client/Region.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/Region.kt
@@ -1,5 +1,8 @@
 package io.tryvital.client
 
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = false)
 enum class Region {
     US, EU
 }

--- a/VitalClient/src/main/java/io/tryvital/client/dependencies/Dependencies.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/dependencies/Dependencies.kt
@@ -2,11 +2,8 @@ package io.tryvital.client.dependencies
 
 import android.content.Context
 import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
-import com.squareup.moshi.Json
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import com.squareup.moshi.rawType
 import io.tryvital.client.BuildConfig
 import io.tryvital.client.ConfigurationReader
 import io.tryvital.client.Environment
@@ -99,7 +96,6 @@ internal class Dependencies(
                 .build()
 
         internal fun createMoshi(): Moshi = Moshi.Builder()
-            .add(KotlinJsonAdapterFactory())
             .add(Date::class.java, Rfc3339DateJsonAdapter())
             .add(LocalDate::class.java, LocalDateJsonAdapter)
             .add(ProviderSlug::class.java, ProviderSlug.jsonAdapter)

--- a/VitalClient/src/main/java/io/tryvital/client/jwt/VitalJWTAuth.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/jwt/VitalJWTAuth.kt
@@ -3,9 +3,9 @@ package io.tryvital.client.jwt
 import android.content.Context
 import android.content.SharedPreferences
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.tryvital.client.Environment
 import io.tryvital.client.Region
 import io.tryvital.client.VITAL_ENCRYPTED_PERFS_FILE_NAME
@@ -40,7 +40,6 @@ const val AUTH_RECORD_KEY = "auth_record"
 private val moshi by lazy {
     Moshi.Builder()
         .add(Date::class.java, Rfc3339DateJsonAdapter())
-        .addLast(KotlinJsonAdapterFactory())
         .build()
 }
 
@@ -344,7 +343,8 @@ internal class VitalJWTAuth(
     }
 }
 
-private data class VitalJWTAuthRecord(
+@JsonClass(generateAdapter = true)
+internal data class VitalJWTAuthRecord(
     val environment: Environment,
     val userId: String,
     val teamId: String,
@@ -358,7 +358,8 @@ private data class VitalJWTAuthRecord(
     fun isExpired(now: Date = Date.from(Instant.now())) = expiry.before(now)
 }
 
-private data class FirebaseTokenRefreshResponse(
+@JsonClass(generateAdapter = true)
+internal data class FirebaseTokenRefreshResponse(
     @Json(name = "expires_in")
     val expiresIn: String,
     @Json(name = "refresh_token")
@@ -367,11 +368,13 @@ private data class FirebaseTokenRefreshResponse(
     val idToken: String,
 )
 
-private data class FirebaseTokenRefreshErrorResponse(
+@JsonClass(generateAdapter = true)
+internal data class FirebaseTokenRefreshErrorResponse(
     val error: FirebaseTokenRefreshError
 )
 
-private data class FirebaseTokenRefreshError(
+@JsonClass(generateAdapter = true)
+internal data class FirebaseTokenRefreshError(
     val message: String,
     val status: String,
 ) {
@@ -382,18 +385,21 @@ private data class FirebaseTokenRefreshError(
         get() = arrayOf("TOKEN_EXPIRED", "INVALID_REFRESH_TOKEN").contains(message)
 }
 
-private data class FirebaseTokenExchangeRequest(
+@JsonClass(generateAdapter = true)
+internal data class FirebaseTokenExchangeRequest(
     val returnSecureToken: Boolean = true,
     val token: String,
     val tenantId: String,
 )
 
-private data class FirebaseTokenExchangeResponse(
+@JsonClass(generateAdapter = true)
+internal data class FirebaseTokenExchangeResponse(
     val expiresIn: String,
     val refreshToken: String,
     val idToken: String,
 )
 
+@JsonClass(generateAdapter = true)
 internal data class VitalSignInToken(
     @Json(name = "public_key")
     val publicKey: String,
@@ -475,7 +481,8 @@ internal data class VitalSignInTokenClaims(
         }
     }
 
-    private data class RawClaims(
+    @JsonClass(generateAdapter = true)
+    internal data class RawClaims(
         @Json(name = "iss")
         val issuer: String,
         @Json(name = "uid")
@@ -486,7 +493,8 @@ internal data class VitalSignInTokenClaims(
         val gcipTenantId: String,
     )
 
-    private data class RawInnerClaims(
+    @JsonClass(generateAdapter = true)
+    internal data class RawInnerClaims(
         @Json(name = "vital_team_id")
         val teamId: String
     )

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Activity.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Activity.kt
@@ -1,13 +1,16 @@
 package io.tryvital.client.services.data
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.time.LocalDate
 import java.util.*
 
+@JsonClass(generateAdapter = true)
 data class ActivitiesResponse(
     val activity: List<Activity>
 )
 
+@JsonClass(generateAdapter = true)
 data class Activity(
     @Json(name = "user_id")
     val userId: String?,
@@ -28,6 +31,7 @@ data class Activity(
     val source: Source,
 )
 
+@JsonClass(generateAdapter = true)
 data class ActivityDaySummary(
     @Json(name = "calendar_date")
     val date: LocalDate,

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Body.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Body.kt
@@ -1,13 +1,16 @@
 package io.tryvital.client.services.data
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.util.*
 
+@JsonClass(generateAdapter = true)
 data class BodyDataResponse(
     val body: List<BodyData>
 )
 
-class BodyData(
+@JsonClass(generateAdapter = true)
+data class BodyData(
     @Json(name = "user_id")
     val userId: String?,
     @Json(name = "user_key")

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/CholesterolType.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/CholesterolType.kt
@@ -1,7 +1,9 @@
 package io.tryvital.client.services.data
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 
+@JsonClass(generateAdapter = false)
 enum class CholesterolType {
     @Json(name = "ldn")
     Ldn,

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/ControlPlane.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/ControlPlane.kt
@@ -1,7 +1,9 @@
 package io.tryvital.client.services.data
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 
+@JsonClass(generateAdapter = true)
 data class CreateSignInTokenResponse(
     @Json(name = "user_id")
     val userId: String,

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/DataStage.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/DataStage.kt
@@ -1,7 +1,9 @@
 package io.tryvital.client.services.data
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 
+@JsonClass(generateAdapter = false)
 enum class DataStage {
     @Json(name = "historical")
     Historical,

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Link.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Link.kt
@@ -1,8 +1,10 @@
 package io.tryvital.client.services.data
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import io.tryvital.client.Region
 
+@JsonClass(generateAdapter = true)
 data class CreateLinkRequest(
     @Json(name = "user_id")
     val userId: String,
@@ -11,7 +13,7 @@ data class CreateLinkRequest(
     val redirectUrl: String,
 )
 
-
+@JsonClass(generateAdapter = true)
 data class PasswordProviderRequest(
     val username: String,
     val password: String,
@@ -19,11 +21,13 @@ data class PasswordProviderRequest(
     val redirectUrl: String,
 )
 
+@JsonClass(generateAdapter = true)
 data class EmailProviderRequest(
     val email: String,
     val region: Region,
 )
 
+@JsonClass(generateAdapter = true)
 data class ManualProviderRequest(
     @Json(name = "user_id")
     val userId: String,
@@ -31,11 +35,13 @@ data class ManualProviderRequest(
     val providerId: String? = null,
 )
 
+@JsonClass(generateAdapter = true)
 data class CreateLinkResponse(
     @Json(name = "link_token")
     val linkToken: String?,
 )
 
+@JsonClass(generateAdapter = true)
 data class OauthLinkResponse(
     val name: String?,
     val slug: String?,
@@ -51,12 +57,14 @@ data class OauthLinkResponse(
     val id: Int,
 )
 
+@JsonClass(generateAdapter = true)
 data class EmailProviderResponse(
     val success: Boolean,
     @Json(name = "redirect_url")
     val redirectUrl: String?,
 )
 
+@JsonClass(generateAdapter = true)
 data class ManualProviderResponse(
     @Json(name = "success")
     val success: Boolean,

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Measurement.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Measurement.kt
@@ -1,7 +1,9 @@
 package io.tryvital.client.services.data
 
+import com.squareup.moshi.JsonClass
 import java.util.*
 
+@JsonClass(generateAdapter = true)
 data class Measurement(
     val id: Int,
     val timestamp: Date,

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Profile.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Profile.kt
@@ -1,7 +1,9 @@
 package io.tryvital.client.services.data
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 
+@JsonClass(generateAdapter = true)
 data class Profile(
     @Json(name = "user_id")
     val userId: String,

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Sleep.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Sleep.kt
@@ -1,12 +1,15 @@
 package io.tryvital.client.services.data
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.util.*
 
+@JsonClass(generateAdapter = true)
 data class SleepResponse(
     val sleep: List<SleepData>
 )
 
+@JsonClass(generateAdapter = true)
 data class SleepData(
     @Json(name = "user_id")
     val userId: String?,
@@ -44,6 +47,7 @@ data class SleepData(
     val sleepStream: SleepStreamResponse?,
 )
 
+@JsonClass(generateAdapter = true)
 data class SleepStreamResponse(
     val hrv: List<Measurement> = emptyList(),
     val heartrate: List<Measurement> = emptyList(),

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Summary.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Summary.kt
@@ -1,8 +1,10 @@
 package io.tryvital.client.services.data
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.util.*
 
+@JsonClass(generateAdapter = true)
 data class SummaryPayload<T>(
     @Json(name = "stage")
     val stage: DataStage,
@@ -18,6 +20,7 @@ data class SummaryPayload<T>(
     val data: T
 )
 
+@JsonClass(generateAdapter = true)
 data class WorkoutPayload(
     @Json(name = "id")
     val id: String,
@@ -41,6 +44,7 @@ data class WorkoutPayload(
     val respiratoryRate: List<QuantitySamplePayload>
 )
 
+@JsonClass(generateAdapter = true)
 data class ActivityPayload(
     @Json(name = "day_summary")
     val daySummary: ActivityDaySummary?,
@@ -58,6 +62,7 @@ data class ActivityPayload(
     val floorsClimbed: List<QuantitySamplePayload>,
 )
 
+@JsonClass(generateAdapter = true)
 data class ProfilePayload(
     @Json(name = "biological_sex")
     val biologicalSex: String,
@@ -67,6 +72,7 @@ data class ProfilePayload(
     val heightInCm: Int,
 )
 
+@JsonClass(generateAdapter = true)
 data class BodyPayload(
     @Json(name = "body_mass")
     val bodyMass: List<QuantitySamplePayload>,
@@ -74,6 +80,7 @@ data class BodyPayload(
     val bodyFatPercentage: List<QuantitySamplePayload>,
 )
 
+@JsonClass(generateAdapter = true)
 data class SleepPayload(
     @Json(name = "id")
     val id: String,
@@ -97,6 +104,7 @@ data class SleepPayload(
     val respiratoryRate: List<QuantitySamplePayload>,
 )
 
+@JsonClass(generateAdapter = true)
 data class QuantitySamplePayload(
     @Json(name = "id")
     val id: String? = null,
@@ -118,6 +126,7 @@ data class QuantitySamplePayload(
     val metadata: String? = null,
 )
 
+@JsonClass(generateAdapter = true)
 data class BloodPressureSamplePayload(
     @Json(name = "systolic")
     val systolic: QuantitySamplePayload,

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Timeseries.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Timeseries.kt
@@ -5,6 +5,7 @@ import com.squareup.moshi.JsonClass
 import io.tryvital.client.utils.getJsonName
 import java.util.*
 
+@JsonClass(generateAdapter = true)
 data class TimeseriesPayload<T> (
     @Json(name = "stage")
     val stage: DataStage,

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/User.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/User.kt
@@ -1,8 +1,10 @@
 package io.tryvital.client.services.data
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.util.*
 
+@JsonClass(generateAdapter = true)
 data class User(
     @Json(name = "user_id")
     val userId: String,
@@ -18,18 +20,21 @@ data class User(
     val connectedSources: List<ConnectedSource>
 )
 
+@JsonClass(generateAdapter = true)
 data class ConnectedSource(
     val source: Source,
     @Json(name = "created_on")
     val createdOn: Date
 )
 
+@JsonClass(generateAdapter = true)
 data class Source(
     val name: String,
     val slug: ProviderSlug,
     val logo: String?
 )
 
+@JsonClass(generateAdapter = true)
 data class RefreshResponse(
     val success: Boolean,
     @Json(name = "user_id")
@@ -41,10 +46,12 @@ data class RefreshResponse(
     val failedSources: List<String> = emptyList()
 )
 
+@JsonClass(generateAdapter = true)
 data class ProvidersResponse(
     val providers: List<Source> = emptyList()
 )
 
+@JsonClass(generateAdapter = true)
 data class CreateUserRequest(
     @Json(name = "client_user_id")
     val clientUserId: String,
@@ -52,6 +59,7 @@ data class CreateUserRequest(
     val fallbackTimeZone: String? = null
 )
 
+@JsonClass(generateAdapter = true)
 data class CreateUserResponse(
     @Json(name = "user_id")
     val userId: String,
@@ -61,15 +69,18 @@ data class CreateUserResponse(
     val clientUserId: String
 )
 
+@JsonClass(generateAdapter = true)
 data class DeleteUserResponse(
     val success: Boolean,
     val error: String?
 )
 
+@JsonClass(generateAdapter = true)
 data class DeregisterProviderResponse(
     val success: Boolean
 )
 
+@JsonClass(generateAdapter = true)
 data class GetAllUsersResponse(
     @Json(name = "users")
     val users: List<User>?

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Workout.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Workout.kt
@@ -1,12 +1,15 @@
 package io.tryvital.client.services.data
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.util.*
 
+@JsonClass(generateAdapter = true)
 data class WorkoutsResponse(
     val workouts: List<Workout>
 )
 
+@JsonClass(generateAdapter = true)
 data class Workout(
     @Json(name = "user_id")
     val userId: String,
@@ -55,11 +58,13 @@ data class Workout(
     val source: Source,
 )
 
+@JsonClass(generateAdapter = true)
 data class Sport(
     val id: Int,
     val name: String,
 )
 
+@JsonClass(generateAdapter = true)
 data class MapData(
     val id: String,
     val polyline: String?,
@@ -67,6 +72,7 @@ data class MapData(
     val summaryPolyline: String?,
 )
 
+@JsonClass(generateAdapter = true)
 data class WorkoutStreamResponse(
     val time: List<Int> = listOf(),
     val cadence: List<Double> = listOf(),

--- a/VitalHealthConnect/build.gradle
+++ b/VitalHealthConnect/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'com.google.devtools.ksp' version "$ksp"
 }
 
 android {
@@ -39,11 +40,15 @@ android {
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
         kotlinOptions {
             freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+            jvmTarget = JavaVersion.VERSION_1_8.toString()
         }
     }
 }
 
+
 dependencies {
+    ksp "com.squareup.moshi:moshi-kotlin-codegen:$moshi"
+
     implementation project(':VitalClient')
 
     implementation "androidx.health.connect:connect-client:$health_connect"
@@ -56,7 +61,6 @@ dependencies {
     implementation "androidx.work:work-runtime-ktx:$work_runtime"
 
     implementation "com.squareup.moshi:moshi:$moshi"
-    implementation "com.squareup.moshi:moshi-kotlin:$moshi"
     implementation "com.squareup.moshi:moshi-adapters:$moshi"
 
     testImplementation "junit:junit:$junit"

--- a/VitalHealthConnect/consumer-rules.pro
+++ b/VitalHealthConnect/consumer-rules.pro
@@ -1,2 +1,0 @@
--keep class io.tryvital.vitalhealthconnect.workers.ResourceSyncState
--keep class io.tryvital.vitalhealthconnect.workers.ResourceSyncState { *; }

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncWorker.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncWorker.kt
@@ -7,20 +7,15 @@ import androidx.health.connect.client.request.ChangesTokenRequest
 import androidx.health.connect.client.response.ChangesResponse
 import androidx.work.CoroutineWorker
 import androidx.work.Data
-import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
+import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import io.tryvital.client.Environment
-import io.tryvital.client.Region
 import io.tryvital.client.VitalClient
 import io.tryvital.client.services.data.DataStage
 import io.tryvital.client.utils.VitalLogger
 import io.tryvital.vitalhealthconnect.HealthConnectClientProvider
-import io.tryvital.vitalhealthconnect.SyncNotificationBuilder
-import io.tryvital.vitalhealthconnect.VitalHealthConnectManager
 import io.tryvital.vitalhealthconnect.ext.toDate
 import io.tryvital.vitalhealthconnect.model.VitalResource
 import io.tryvital.vitalhealthconnect.model.processedresource.ProcessedResourceData
@@ -33,7 +28,6 @@ import io.tryvital.vitalhealthconnect.records.RecordProcessor
 import io.tryvital.vitalhealthconnect.records.RecordReader
 import io.tryvital.vitalhealthconnect.records.RecordUploader
 import io.tryvital.vitalhealthconnect.records.VitalClientRecordUploader
-import kotlinx.coroutines.delay
 import java.time.Instant
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
@@ -46,7 +40,6 @@ internal val moshi by lazy {
     Moshi.Builder()
         .add(Date::class.java, Rfc3339DateJsonAdapter())
         .add(ResourceSyncState.adapterFactory)
-        .addLast(KotlinJsonAdapterFactory())
         .build()
 }
 
@@ -67,8 +60,11 @@ data class ResourceSyncWorkerInput(
     }
 }
 
+@JsonClass(generateAdapter = false)
 sealed class ResourceSyncState {
+    @JsonClass(generateAdapter = true)
     data class Historical(val start: Date, val end: Date) : ResourceSyncState()
+    @JsonClass(generateAdapter = true)
     data class Incremental(val changesToken: String, val lastSync: Date) : ResourceSyncState()
 
     companion object {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'com.google.devtools.ksp' version "$ksp"
 }
 
 android {
@@ -59,21 +60,23 @@ android {
             freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
             freeCompilerArgs += "-P"
             freeCompilerArgs += "plugin:androidx.compose.compiler.plugins.kotlin:suppressKotlinVersionCompatibilityCheck=true"
+            jvmTarget = JavaVersion.VERSION_1_8.toString()
         }
     }
 }
 
 dependencies {
+    ksp "com.squareup.moshi:moshi-kotlin-codegen:$moshi"
+
     implementation project(':VitalClient')
     implementation project(':VitalDevices')
     implementation project(':VitalHealthConnect')
 
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.3")
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:$desugar_jdk_libs")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin"
 
     implementation "com.squareup.moshi:moshi:$moshi"
-    implementation "com.squareup.moshi:moshi-kotlin:$moshi"
     implementation "com.squareup.moshi:moshi-adapters:$moshi"
 
     implementation "androidx.core:core-ktx:$core"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,6 +19,3 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
-
--keep class io.tryvital.sample.AppSettings
--keep class io.tryvital.sample.ui.settings.SettingsAuthMode { public *; }

--- a/app/src/main/java/io/tryvital/sample/AppSettingsStore.kt
+++ b/app/src/main/java/io/tryvital/sample/AppSettingsStore.kt
@@ -3,8 +3,8 @@ package io.tryvital.sample
 import android.content.Context
 import android.content.Context.MODE_PRIVATE
 import android.content.SharedPreferences
+import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.tryvital.client.Environment
 import io.tryvital.client.Region
 import io.tryvital.sample.ui.settings.SettingsAuthMode
@@ -52,6 +52,7 @@ class AppSettingsStore(
     }
 }
 
+@JsonClass(generateAdapter = true)
 data class AppSettings(
     val authMode: SettingsAuthMode = SettingsAuthMode.ApiKey,
     val apiKey: String = "",
@@ -63,6 +64,5 @@ data class AppSettings(
 
 private val moshi by lazy {
     Moshi.Builder()
-        .addLast(KotlinJsonAdapterFactory())
         .build()
 }

--- a/app/src/main/java/io/tryvital/sample/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/tryvital/sample/ui/settings/SettingsViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.squareup.moshi.JsonClass
 import io.tryvital.client.Environment
 import io.tryvital.client.Region
 import io.tryvital.client.VitalClient
@@ -163,6 +164,7 @@ class SettingsViewModel(private val store: AppSettingsStore): ViewModel() {
     }
 }
 
+@JsonClass(generateAdapter = false)
 enum class SettingsAuthMode {
     ApiKey, SignInTokenDemo;
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,11 @@ buildscript {
     ext {
         core = '1.9.0'
         compose = '1.4.1'
+
+        // Linked with Kotlin compiler version
         compose_compiler = '1.4.8'
-        desugar_jdk_libs = '1.2.2'
+
+        desugar_jdk_libs = '1.2.3'
         nav = '2.5.3'
         material3 = '1.0.1'
         activity_compose = '1.6.1'
@@ -30,14 +33,21 @@ buildscript {
         startup_runtime = "1.1.1"
         security_crypto = "1.0.0"
         kotlin = '1.8.22'
+        ksp = '1.8.22-1.0.11'
         kotlinx_coroutines = "1.6.4"
         work_runtime = "2.7.1"
     }
 }
 
 plugins {
+    // Android Gradle Plugin 7.3.0 (not recommended)
+    // id 'com.android.application' version '7.3.0' apply false
+    // id 'com.android.library' version '7.3.0' apply false
+
+    // Android Gradle Plugin 8.2.0
     id 'com.android.application' version '8.2.0' apply false
     id 'com.android.library' version '8.2.0' apply false
+
     id 'org.jetbrains.kotlin.android' version '1.8.22' apply false
 }
 


### PR DESCRIPTION
Struggle to get Moshi reflective serialization working with R8 minification of Android Gradle Plugin 7.x, even though it works fine under AGP 8.x.

This PR migrates all JSON models to use Moshi codegen serialization, and removes the dependency on `moshi-kotlin` and `kotlin-reflect`.

Tested with R8 minification with both AGP 7.x and 8.x.