### PR TITLE
CS1-120: Ability to Pause Health Connect Synchronization

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
     <list size="1">

--- a/VitalClient/src/main/java/io/tryvital/client/VitalClient.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/VitalClient.kt
@@ -140,7 +140,7 @@ class VitalClient internal constructor(context: Context) {
 
     fun checkUserId(): String {
         return currentUserId ?: throw IllegalStateException(
-            "You need to call setUserId before you can read the health data"
+            "The SDK does not have a signed-in user, or is not configured with an API Key for evaluation."
         )
     }
 

--- a/VitalClient/src/main/java/io/tryvital/client/userConnectedSources.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/userConnectedSources.kt
@@ -13,7 +13,7 @@ fun VitalClient.hasUserConnectedTo(provider: ProviderSlug): Boolean {
 }
 
 suspend fun VitalClient.createConnectedSourceIfNotExist(provider: ManualProviderSlug) {
-    val userId = VitalClient.currentUserId ?: return
+    val userId = checkUserId()
     val slug = provider.toProviderSlug()
     if (hasUserConnectedTo(slug)) {
         // Local Hit: The client has witnessed a valid connected source for this provider before.
@@ -53,7 +53,7 @@ suspend fun VitalClient.createConnectedSourceIfNotExist(provider: ManualProvider
 }
 
 suspend fun VitalClient.userConnectedSources(): List<Source> {
-    val userId = VitalClient.currentUserId ?: return emptyList()
+    val userId = checkUserId()
     resetCachedUserConnectedSourceRecordIfNeeded()
 
     val response = userService.getProviders(userId = userId)

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/Utils.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/Utils.kt
@@ -8,6 +8,7 @@ object UnSecurePrefKeys {
     internal const val loggerEnabledKey = "loggerEnabled"
     internal const val syncOnAppStartKey = "syncOnAppStartKey"
     internal const val numberOfDaysToBackFillKey = "numberOfDaysToBackFill"
+    internal const val pauseSyncKey = "pauseSync"
     internal fun readResourceGrant(resource: VitalResource) = "resource.read.$resource"
     internal fun writeResourceGrant(resource: WritableVitalResource) = "resource.write.$resource"
 }

--- a/app/src/main/java/io/tryvital/sample/ui/healthconnect/HealthConnectCard.kt
+++ b/app/src/main/java/io/tryvital/sample/ui/healthconnect/HealthConnectCard.kt
@@ -3,6 +3,7 @@ package io.tryvital.sample.ui.healthconnect
 import android.content.Intent
 import android.net.Uri
 import android.util.Log
+import android.widget.ToggleButton
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
@@ -11,7 +12,10 @@ import androidx.compose.material.icons.outlined.InstallMobile
 import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -69,6 +73,8 @@ fun PermissionInfo(
                 viewModel.checkPermissions()
             }
         }
+
+    val pauseSync = remember { mutableStateOf(viewModel.pauseSync) }
 
     Column(
         modifier = Modifier
@@ -135,6 +141,20 @@ fun PermissionInfo(
                 Spacer(Modifier.size(ButtonDefaults.IconSpacing))
                 Text("Open Health Connect")
             }
+        }
+
+        Spacer(Modifier.height(8.dp))
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Switch(
+                checked = pauseSync.value,
+                onCheckedChange = {
+                    viewModel.pauseSync = it
+                    pauseSync.value = it
+                }
+            )
+            Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+            Text("Pause Synchronization")
         }
     }
 }

--- a/app/src/main/java/io/tryvital/sample/ui/healthconnect/HealthConnectViewModel.kt
+++ b/app/src/main/java/io/tryvital/sample/ui/healthconnect/HealthConnectViewModel.kt
@@ -26,6 +26,11 @@ class HealthConnectViewModel(context: Context) : ViewModel() {
     private val vitalHealthConnectManager = VitalHealthConnectManager.getOrCreate(context)
 
     private val viewModelState = MutableStateFlow(HealthConnectViewModelState())
+
+    var pauseSync: Boolean
+        get() = vitalHealthConnectManager.pauseSynchronization
+        set(newValue) { vitalHealthConnectManager.pauseSynchronization = newValue }
+
     val uiState = viewModelState.asStateFlow()
 
     val userId: String get() = VitalClient.currentUserId ?: "<null>"


### PR DESCRIPTION
Introduce `VitalHealthConnectManager.pauseSynchronization` which can pause synchronisation without having to reset the SDK via `cleanUp()`.

This will also auto-trigger a sync on unpause.