### PR TITLE
VIT-5856: Improve SDK reset behaviours

### DIFF
--- a/VitalClient/src/main/java/io/tryvital/client/VitalClient.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/VitalClient.kt
@@ -94,7 +94,10 @@ class VitalClient internal constructor(context: Context) {
     /** Moments which can materially change VitalClient.Companion.status */
     private val statusChanged = MutableSharedFlow<Unit>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_LATEST)
 
-    fun cleanUp() {
+    @Deprecated("Renamed to `signOut()`.", ReplaceWith("signOut()"))
+    fun cleanUp() = signOut()
+
+    fun signOut() {
         sharedPreferences.edit().clear().apply()
         encryptedSharedPreferences.edit().clear().apply()
         jwtAuth.signOut()

--- a/VitalClient/src/main/java/io/tryvital/client/VitalClient.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/VitalClient.kt
@@ -2,19 +2,28 @@ package io.tryvital.client
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.provider.Settings.Global
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
 import io.tryvital.client.dependencies.Dependencies
 import io.tryvital.client.jwt.VitalJWTAuth
+import io.tryvital.client.jwt.VitalJWTAuthChangeReason
 import io.tryvital.client.jwt.VitalSignInToken
 import io.tryvital.client.services.*
 import io.tryvital.client.utils.VitalLogger
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
 
 const val VITAL_PERFS_FILE_NAME: String = "vital_health_connect_prefs"
 const val VITAL_ENCRYPTED_PERFS_FILE_NAME: String = "safe_vital_health_connect_prefs"
@@ -184,11 +193,13 @@ class VitalClient internal constructor(context: Context) {
 
         fun statusChanged(context: Context): Flow<Unit> {
             val client = getOrCreate(context)
-            return merge(client.statusChanged, client.jwtAuth.statusChanged).conflate()
+            return client.statusChanged
         }
 
         fun statuses(context: Context): Flow<Set<Status>> {
-            return statusChanged(context).map { this.status }.conflate()
+            return statusChanged(context)
+                .onStart { emit(Unit) }
+                .map { this.status }
         }
 
         /**
@@ -207,10 +218,12 @@ class VitalClient internal constructor(context: Context) {
             }
 
         fun getOrCreate(context: Context): VitalClient = synchronized(VitalClient) {
+            val appContext = context.applicationContext
             var instance = sharedInstance
             if (instance == null) {
-                instance = VitalClient(context)
+                instance = VitalClient(appContext)
                 sharedInstance = instance
+                bind(instance, VitalJWTAuth.getInstance(appContext), context)
             }
             return instance
         }
@@ -282,6 +295,27 @@ class VitalClient internal constructor(context: Context) {
 
         suspend fun debugForceTokenRefresh(context: Context) {
             VitalJWTAuth.getInstance(context).refreshToken()
+        }
+
+        /**
+         * Must be called exactly once after Core SDK is initialized.
+         */
+        @OptIn(DelicateCoroutinesApi::class)
+        private fun bind(client: VitalClient, jwtAuth: VitalJWTAuth, context: Context) {
+            jwtAuth.statusChanged
+                .filter { it == VitalJWTAuthChangeReason.UserNoLongerValid }
+                .onEach {
+                    client.cleanUp()
+                }
+                .launchIn(GlobalScope)
+
+
+            statuses(context)
+                .onEach { statuses ->
+                    val logger = VitalLogger.getOrCreate()
+                    logger.info { "status: ${statuses.joinToString(separator = ",") { it.name }}" }
+                }
+                .launchIn(GlobalScope)
         }
     }
 

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
@@ -98,10 +98,12 @@ class VitalHealthConnectManager private constructor(
     @SuppressLint("ApplySharedPref")
     @Suppress("unused")
     fun cleanUp() {
+        vitalClient.cleanUp()
+    }
+
+    private fun resetAutoSync() {
         taskScope.cancel()
         taskScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-
-        vitalClient.cleanUp()
     }
 
     @Suppress("unused")
@@ -362,6 +364,7 @@ class VitalHealthConnectManager private constructor(
     companion object {
         private const val packageName = "com.google.android.apps.healthdata"
 
+        @SuppressLint("StaticFieldLeak")
         private var sharedInstance: VitalHealthConnectManager? = null
 
         @Suppress("unused")
@@ -392,25 +395,42 @@ class VitalHealthConnectManager private constructor(
         }
 
         fun getOrCreate(context: Context): VitalHealthConnectManager = synchronized(VitalHealthConnectManager) {
+            val appContext = context.applicationContext
             var instance = sharedInstance
 
             if (instance == null) {
+                val coreClient = VitalClient.getOrCreate(appContext)
                 val healthConnectClientProvider = HealthConnectClientProvider()
 
                 instance = VitalHealthConnectManager(
-                    context,
+                    appContext,
                     healthConnectClientProvider,
-                    VitalClient.getOrCreate(context),
-                    HealthConnectRecordReader(context, healthConnectClientProvider),
+                    coreClient,
+                    HealthConnectRecordReader(appContext, healthConnectClientProvider),
                     HealthConnectRecordProcessor(
-                        HealthConnectRecordReader(context, healthConnectClientProvider),
-                        HealthConnectRecordAggregator(context, healthConnectClientProvider),
+                        HealthConnectRecordReader(appContext, healthConnectClientProvider),
+                        HealthConnectRecordAggregator(appContext, healthConnectClientProvider),
                     )
                 )
                 sharedInstance = instance
+                bind(instance, coreClient, appContext)
             }
 
             return instance
+        }
+
+        /**
+         * Must be called exactly once after both Core SDK and Health SDK are initialized.
+         */
+        @OptIn(DelicateCoroutinesApi::class)
+        private fun bind(client: VitalHealthConnectManager, coreClient: VitalClient, context: Context) {
+            VitalClient.Companion.statuses(context)
+                .onEach { statuses ->
+                    if (VitalClient.Status.SignedIn !in statuses) {
+                        client.resetAutoSync()
+                    }
+                }
+                .launchIn(GlobalScope)
         }
     }
 }

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
@@ -95,10 +95,12 @@ class VitalHealthConnectManager private constructor(
      *
      * You typically only need to [cleanUp] when your application has logged out the current user.
      */
-    @SuppressLint("ApplySharedPref")
+    @Deprecated(
+        "Use [VitalClient.signOut]. It resets both the Vital Core and Health SDKs."
+    )
     @Suppress("unused")
     fun cleanUp() {
-        vitalClient.cleanUp()
+        vitalClient.signOut()
     }
 
     private fun resetAutoSync() {

--- a/app/src/main/java/io/tryvital/sample/VitalSDKInitializer.kt
+++ b/app/src/main/java/io/tryvital/sample/VitalSDKInitializer.kt
@@ -3,13 +3,17 @@ package io.tryvital.sample
 import android.content.Context
 import androidx.startup.Initializer
 import io.tryvital.client.VitalClient
+import io.tryvital.client.utils.VitalLogger
 import io.tryvital.vitalhealthconnect.VitalHealthConnectManager
 
 class VitalSDKInitializer : Initializer<VitalHealthConnectManager> {
     override fun create(context: Context): VitalHealthConnectManager {
+        VitalLogger.getOrCreate().enabled = true
+
         return VitalHealthConnectManager.getOrCreate(context).apply {
             if (VitalClient.Status.SignedIn in VitalClient.status) {
                 configureHealthConnectClient(
+                    logsEnabled = true,
                     syncNotificationBuilder = VitalSyncNotificationBuilder
                 )
             }

--- a/app/src/main/java/io/tryvital/sample/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/tryvital/sample/ui/settings/SettingsViewModel.kt
@@ -93,7 +93,12 @@ class SettingsViewModel(private val store: AppSettingsStore): ViewModel() {
 
     fun forceTokenRefresh(context: Context) {
         viewModelScope.launch {
-            VitalClient.debugForceTokenRefresh(context)
+            try {
+                VitalClient.debugForceTokenRefresh(context)
+            } catch (e: Throwable) {
+                VitalLogger.getOrCreate().logE("Demo: Force Token Refresh Failed", e)
+                viewModelState.update { it.copy(currentError = e) }
+            }
         }
     }
 

--- a/app/src/main/java/io/tryvital/sample/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/tryvital/sample/ui/settings/SettingsViewModel.kt
@@ -137,7 +137,7 @@ class SettingsViewModel(private val store: AppSettingsStore): ViewModel() {
     }
 
     fun resetSDK(context: Context) {
-        VitalClient.getOrCreate(context).cleanUp()
+        VitalClient.getOrCreate(context).signOut()
         updateSDKStatus(context)
     }
 


### PR DESCRIPTION
* Fixed broken parsing of token refresh error response. `FirebaseTokenRefreshErrorResponse` should be used instead of `FirebaseTokenRefreshError`.

* If the signed-in user is deleted, the SDK now self-resets as if `VitalHealthConnectManager.cleanUp()` is called.

* Resetting the Core SDK also cancels the Health SDK data sync.