### PR TITLE
VIT-6004: Background Sync on app resume

### DIFF
--- a/VitalHealthConnect/build.gradle
+++ b/VitalHealthConnect/build.gradle
@@ -47,6 +47,7 @@ android {
 
 
 dependencies {
+    implementation "androidx.lifecycle:lifecycle-process:$lifecycle_process"
     ksp "com.squareup.moshi:moshi-kotlin-codegen:$moshi"
 
     implementation project(':VitalClient')

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/SyncBroadcastReceiver.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/SyncBroadcastReceiver.kt
@@ -48,9 +48,9 @@ class SyncBroadcastReceiver: BroadcastReceiver() {
             return VitalLogger.getOrCreate().info { "BgSync: skipped launch - sync paused" }
         }
 
-        manager.launchSyncWorkerFromBackground {
-            check(Looper.getMainLooper().isCurrentThread)
+        manager.launchAutoSyncWorker {
             context.startForegroundService(intent)
+            VitalLogger.getOrCreate().info { "BgSync: triggered by exact alarm" }
         }
     }
 }

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/Utils.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/Utils.kt
@@ -11,6 +11,7 @@ object UnSecurePrefKeys {
     internal const val pauseSyncKey = "pauseSync"
     internal const val useExactAlarmKey = "useExactAlarm"
     internal const val nextAlarmAtKey = "nextAlarmAt"
+    internal const val lastAutoSyncedAtKey = "lastAutoSyncedAt"
     internal fun readResourceGrant(resource: VitalResource) = "resource.read.$resource"
     internal fun writeResourceGrant(resource: WritableVitalResource) = "resource.write.$resource"
 }

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/processLifecycleObserver.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/processLifecycleObserver.kt
@@ -1,0 +1,36 @@
+package io.tryvital.vitalhealthconnect
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import io.tryvital.client.VitalClient
+import io.tryvital.client.utils.VitalLogger
+import io.tryvital.vitalhealthconnect.model.HealthConnectAvailability
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
+
+internal fun processLifecycleObserver(
+    manager: VitalHealthConnectManager
+) = object: LifecycleEventObserver {
+    override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+        if (event != Lifecycle.Event.ON_START) {
+            return
+        }
+
+        manager.scheduleNextExactAlarm(force = false)
+
+        source.lifecycleScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            manager.checkAndUpdatePermissions()
+
+            if (
+                VitalClient.Status.SignedIn in VitalClient.status
+                && VitalHealthConnectManager.isAvailable(manager.context) == HealthConnectAvailability.Installed
+            ) {
+                manager.launchAutoSyncWorker {
+                    VitalLogger.getOrCreate().info { "BgSync: triggered by process ON_START" }
+                }
+            }
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
         lifecycle_runtime = '2.5.1'
         lifecycle_viewmodel_compose = '2.5.1'
         lifecycle_livedata_ktx = '2.6.1'
+        lifecycle_process = '2.7.0'
         browser = '1.4.0'
         retrofit = '2.9.0'
         retrofit2_kotlin_coroutines_adapter = '0.9.2'


### PR DESCRIPTION
The SDK currently only automatically sync on process (app) recreation, which is a fairly low frequency event unless the user constantly force-closes the app.

Adopt `ProcessLifecycleOwner` so that we can bind the SDK to the ON_START event, which happens every time the user switches back to the app.