### PR TITLE
VIT-6019: Tune auto-sync behaviour after more testing

### DIFF
--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalPermissionRequestContract.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalPermissionRequestContract.kt
@@ -74,11 +74,11 @@ class VitalPermissionRequestContract(
             // The activity result reports only permissions granted in this UI interaction.
             // Since we have VitalResources that are an aggregate of multiple record types, we need
             // to recompute based on the full set of permissions.
-            manager.checkAndUpdatePermissions()
+            val discoveredNewGrants = manager.checkAndUpdatePermissions()
 
             // Asynchronously start syncing the newly granted read resources
             taskScope.launch {
-                manager.syncData(readGrants)
+                manager.syncData(readGrants + discoveredNewGrants)
             }
 
             PermissionOutcome.Success

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/backgroundSync.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/backgroundSync.kt
@@ -21,7 +21,7 @@ import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 
 private val MIN_SYNC_INTERVAL = 1.hours
-private val AUTO_SYNC_THROTTLE = 10.minutes
+private val AUTO_SYNC_THROTTLE = 2.minutes
 
 @ExperimentalVitalApi
 val VitalHealthConnectManager.isBackgroundSyncEnabled: Boolean

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/SyncOnExactAlarmService.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/SyncOnExactAlarmService.kt
@@ -33,15 +33,16 @@ class SyncOnExactAlarmService: Service() {
             foregroundServiceType()
         )
 
-        val job = manager.launchAutoSyncWorker(startForeground = false) {
+        val launched = manager.launchAutoSyncWorker(startForeground = false) {
             VitalLogger.getOrCreate().info { "BgSync: sync triggered by SyncOnExactAlarmService" }
         }
 
-        if (job != null) {
+        if (launched) {
             // Use `invokeOnCompletion` so that `done()` is called unconditionally,
             // no matter whether the job is cancelled, completed or failed.
-            job.invokeOnCompletion {
-                mainScope.launch { this@SyncOnExactAlarmService.done() }
+            mainScope.launch {
+                manager.observeSyncWorkerCompleted()
+                this@SyncOnExactAlarmService.done()
             }
         } else {
             this.done()


### PR DESCRIPTION
* Reduce auto-sync trigger throttle from 10 minutes to 2 minute. That is, if a user reopens the app within 1 minute from the last sync, we skip the auto-sync.

* Remove the mitigation of strict rate limits added during Android 14 early betas, since it appears to have been relaxed in subsequent beta & GA releases.

* `syncData()` now consults `WorkManager` for any active sync worker. If one is found, it waits until their completion, rather than spawning new work.

* Auto-sync triggers now all depend on `ExistingWorkPolicy.KEEP` to avoid spawning more work.

* Improve `ask()` to reliably fire sync on non-interactive permission grants, as well as interactive grants as reported by the Health Connect Intent.

* Fix `VitalHealthConnectManager.status` emitting lots of duplicated sync statuses.