### PR TITLE
VIT-6034: Gracefully handle missing permission when generating Health Connect changes token

### DIFF
--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/SyncNotificationBuilder.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/SyncNotificationBuilder.kt
@@ -53,7 +53,8 @@ class DefaultSyncNotificationBuilder(
     }
 
     private fun createChannel(context: Context, content: DefaultSyncNotificationContent): String {
-        val importance = NotificationManager.IMPORTANCE_MIN
+        // We cannot use IMPORTANT_MIN for FGS, or else Android will coerce it to IMPORTANT_HIGH
+        val importance = NotificationManager.IMPORTANCE_LOW
         val mChannel = NotificationChannel("VitalHealthConnectSync", content.channelName, importance)
         mChannel.description = content.channelDescription
         val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/Utils.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/Utils.kt
@@ -13,6 +13,7 @@ object UnSecurePrefKeys {
     internal const val nextAlarmAtKey = "nextAlarmAt"
     internal const val lastAutoSyncedAtKey = "lastAutoSyncedAt"
     internal const val lastSeenWorkIdKey = "lastSeenWorkId"
+    internal const val typesMonitoredByChangesTokenKey = "typesMonitoredByChangesToken"
     internal fun readResourceGrant(resource: VitalResource) = "resource.read.$resource"
     internal fun writeResourceGrant(resource: WritableVitalResource) = "resource.write.$resource"
 }

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/VitalResource.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/VitalResource.kt
@@ -149,6 +149,7 @@ fun VitalResource.recordTypeChangesToTriggerSync(): List<KClass<out Record>> = w
     VitalResource.Water -> listOf(HydrationRecord::class)
     VitalResource.Activity -> listOf(
         ActiveCaloriesBurnedRecord::class,
+        TotalCaloriesBurnedRecord::class,
         BasalMetabolicRateRecord::class,
         StepsRecord::class,
         DistanceRecord::class,


### PR DESCRIPTION
While we handle missing permissions gracefully when doing aggregations for Activity and Workouts, we did not do that when creating changesToken.

This caused ChangesTokenRequest to fail, in cases where:
* A user has not granted permissions for resources aggregating from multiple Record types (e.g. Activity); or
* A Vital customer did not declare usage of all data types (so user cannot grant it to begin with).

This PR does a few changes:

* We now filter the Record types by available read permission, before we make the `ChangesTokenRequest`.
* We now track the set of record types we used to request the changesToken.
* We now detect the scenario where the set of record types we monitor can change as a result of new read permissions being granted. We previously ignore this scenario.


Also fix the misuse of `IMPROTANCE_MIN` in the default sync notification builder.