### PR TITLE
VIT-6150: Android: No historical.data.* event when no data

### DIFF
--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/ProcessedResourceData.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/ProcessedResourceData.kt
@@ -22,16 +22,23 @@ sealed class ProcessedResourceData {
         }
         throw IllegalArgumentException("cannot merge two different cases of ProcessedResourceData")
     }
+
+    fun isNotEmpty() = when (this) {
+        is Summary -> this.summaryData.isNotEmpty()
+        is TimeSeries -> this.timeSeriesData.isNotEmpty()
+    }
 }
 
 sealed class TimeSeriesData {
     abstract fun merge(other: TimeSeriesData): TimeSeriesData
+    abstract fun isNotEmpty(): Boolean
 
     data class BloodPressure(val samples: List<BloodPressureSample>) : TimeSeriesData() {
         override fun merge(other: TimeSeriesData): TimeSeriesData {
             check(other is BloodPressure)
             return BloodPressure(samples + other.samples)
         }
+        override fun isNotEmpty(): Boolean = samples.isNotEmpty()
     }
 
     data class QuantitySamples(val resource: IngestibleTimeseriesResource, val samples: List<QuantitySample>) : TimeSeriesData() {
@@ -39,11 +46,13 @@ sealed class TimeSeriesData {
             check(other is QuantitySamples && resource == other.resource)
             return QuantitySamples(resource, samples + other.samples)
         }
+        override fun isNotEmpty(): Boolean = samples.isNotEmpty()
     }
 }
 
 sealed class SummaryData {
     abstract fun merge(other: SummaryData): SummaryData
+    abstract fun isNotEmpty(): Boolean
 
     data class Profile(
         val biologicalSex: String,
@@ -64,6 +73,8 @@ sealed class SummaryData {
             // RHS bias
             return other
         }
+
+        override fun isNotEmpty(): Boolean = true
     }
 
     data class Body(
@@ -83,6 +94,8 @@ sealed class SummaryData {
             // RHS bias
             return other
         }
+
+        override fun isNotEmpty(): Boolean = bodyMass.isNotEmpty() || bodyFatPercentage.isNotEmpty()
     }
 
     data class Activities(
@@ -92,6 +105,7 @@ sealed class SummaryData {
             check(other is Activities)
             return Activities(activities + other.activities)
         }
+        override fun isNotEmpty(): Boolean = activities.isNotEmpty()
     }
 
     data class Sleeps(
@@ -101,6 +115,7 @@ sealed class SummaryData {
             check(other is Sleeps)
             return Sleeps(samples + other.samples)
         }
+        override fun isNotEmpty(): Boolean = samples.isNotEmpty()
     }
 
     data class Workouts(
@@ -110,6 +125,7 @@ sealed class SummaryData {
             check(other is Workouts)
             return Workouts(samples + other.samples)
         }
+        override fun isNotEmpty(): Boolean = samples.isNotEmpty()
     }
 }
 

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordUploader.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordUploader.kt
@@ -92,18 +92,16 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         sleepPayloads: List<SleepPayload>,
         stage: DataStage,
     ) {
-        if (sleepPayloads.isNotEmpty()) {
-            vitalClient.summaryService.addSleeps(
-                userId, SummaryPayload(
-                    stage = stage,
-                    provider = ManualProviderSlug.HealthConnect,
-                    startDate = startDate,
-                    endDate = endDate,
-                    timeZoneId = timeZoneId,
-                    data = sleepPayloads,
-                )
+        vitalClient.summaryService.addSleeps(
+            userId, SummaryPayload(
+                stage = stage,
+                provider = ManualProviderSlug.HealthConnect,
+                startDate = startDate,
+                endDate = endDate,
+                timeZoneId = timeZoneId,
+                data = sleepPayloads,
             )
-        }
+        )
     }
 
     override suspend fun uploadBody(
@@ -154,18 +152,16 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         activityPayloads: List<ActivityPayload>,
         stage: DataStage,
     ) {
-        if (activityPayloads.isNotEmpty()) {
-            vitalClient.summaryService.addActivities(
-                userId, SummaryPayload(
-                    stage = stage,
-                    provider = ManualProviderSlug.HealthConnect,
-                    startDate = startDate,
-                    endDate = endDate,
-                    timeZoneId = timeZoneId,
-                    data = activityPayloads,
-                )
+        vitalClient.summaryService.addActivities(
+            userId, SummaryPayload(
+                stage = stage,
+                provider = ManualProviderSlug.HealthConnect,
+                startDate = startDate,
+                endDate = endDate,
+                timeZoneId = timeZoneId,
+                data = activityPayloads,
             )
-        }
+        )
     }
 
     override suspend fun uploadWorkouts(
@@ -176,18 +172,16 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         workoutPayloads: List<WorkoutPayload>,
         stage: DataStage,
     ) {
-        if (workoutPayloads.isNotEmpty()) {
-            vitalClient.summaryService.addWorkouts(
-                userId, SummaryPayload(
-                    stage = stage,
-                    provider = ManualProviderSlug.HealthConnect,
-                    startDate = startDate,
-                    endDate = endDate,
-                    timeZoneId = timeZoneId,
-                    data = workoutPayloads,
-                )
+        vitalClient.summaryService.addWorkouts(
+            userId, SummaryPayload(
+                stage = stage,
+                provider = ManualProviderSlug.HealthConnect,
+                startDate = startDate,
+                endDate = endDate,
+                timeZoneId = timeZoneId,
+                data = workoutPayloads,
             )
-        }
+        )
     }
 
     override suspend fun uploadQuantitySamples(
@@ -199,18 +193,16 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         quantitySamples: List<QuantitySamplePayload>,
         stage: DataStage,
     ) {
-        if (quantitySamples.isNotEmpty()) {
-            vitalClient.vitalsService.sendQuantitySamples(
-                resource, userId, TimeseriesPayload(
-                    stage = stage,
-                    provider = ManualProviderSlug.HealthConnect,
-                    startDate = startDate,
-                    endDate = endDate,
-                    timeZoneId = timeZoneId,
-                    data = quantitySamples,
-                )
+        vitalClient.vitalsService.sendQuantitySamples(
+            resource, userId, TimeseriesPayload(
+                stage = stage,
+                provider = ManualProviderSlug.HealthConnect,
+                startDate = startDate,
+                endDate = endDate,
+                timeZoneId = timeZoneId,
+                data = quantitySamples,
             )
-        }
+        )
     }
 
     override suspend fun uploadBloodPressure(
@@ -221,17 +213,15 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         bloodPressurePayloads: List<BloodPressureSamplePayload>,
         stage: DataStage,
     ) {
-        if (bloodPressurePayloads.isNotEmpty()) {
-            vitalClient.vitalsService.sendBloodPressure(
-                userId, TimeseriesPayload(
-                    stage = stage,
-                    provider = ManualProviderSlug.HealthConnect,
-                    startDate = startDate,
-                    endDate = endDate,
-                    timeZoneId = timeZoneId,
-                    data = bloodPressurePayloads,
-                )
+        vitalClient.vitalsService.sendBloodPressure(
+            userId, TimeseriesPayload(
+                stage = stage,
+                provider = ManualProviderSlug.HealthConnect,
+                startDate = startDate,
+                endDate = endDate,
+                timeZoneId = timeZoneId,
+                data = bloodPressurePayloads,
             )
-        }
+        )
     }
 }


### PR DESCRIPTION
We unconditionally skip some upload POST requests when there is no data. This breaks historical.data.* event, which relies on an empty POST request being made by SDKs to signal the end of the historical stage.