### PR TITLE
VIT-6624: Catch up with all API deprecations Pt.2

### DIFF
--- a/VitalClient/src/main/java/io/tryvital/client/dependencies/Dependencies.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/dependencies/Dependencies.kt
@@ -11,6 +11,7 @@ import io.tryvital.client.Region
 import io.tryvital.client.VitalClientUnconfigured
 import io.tryvital.client.jwt.AbstractVitalJWTAuth
 import io.tryvital.client.jwt.VitalJWTAuth
+import io.tryvital.client.services.data.LinkResponse
 import io.tryvital.client.services.data.UserConnectionStatus
 import io.tryvital.client.services.data.ManualProviderSlug
 import io.tryvital.client.services.data.ProviderSlug
@@ -108,6 +109,8 @@ internal class Dependencies(
             .add(VitalAPIResource::class.java, VitalAPIResource.jsonAdapter)
             .add(UserConnectionStatus::class.java, UserConnectionStatus.jsonAdapter)
             .add(SourceType::class.java, SourceType.jsonAdapter)
+            .add(LinkResponse.State::class.java, LinkResponse.State.jsonAdapter)
+            .add(LinkResponse.ProviderMFA.Method::class.java, LinkResponse.ProviderMFA.Method.jsonAdapter)
             .build()
 
         internal fun resolveUrl(configurationReader: ConfigurationReader): String {

--- a/VitalClient/src/main/java/io/tryvital/client/services/LinkService.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/LinkService.kt
@@ -12,31 +12,31 @@ interface LinkService {
     ): CreateLinkResponse
 
     @POST("link/provider/password/{provider}")
-    suspend fun passwordProvider(
+    suspend fun linkPasswordProvider(
         @Path("provider") provider: String,
-        @Body request: PasswordProviderRequest,
-        @Header("LinkToken") linkToken: String,
-    ): EmailProviderResponse
+        @Body request: LinkPasswordProviderInput,
+        @Header("x-vital-link-token") linkToken: String,
+    ): LinkResponse
 
+    @POST("link/provider/password/{provider}/complete_mfa")
+    suspend fun completePasswordProviderMFA(
+        @Path("provider") provider: String,
+        @Body request: CompletePasswordProviderMFAInput,
+        @Header("x-vital-link-token") linkToken: String,
+    ): LinkResponse
 
     @POST("link/provider/email/{provider}")
-    suspend fun emailProvider(
+    suspend fun linkEmailProvider(
         @Path("provider") provider: String,
-        @Body request: EmailProviderRequest,
+        @Body request: LinkEmailProviderInput,
         @Header("x-vital-link-token") linkToken: String,
-    ): EmailProviderResponse
+    ): LinkResponse
 
     @GET("link/provider/oauth/{provider}")
-    suspend fun oauthProvider(
+    suspend fun linkOauthProvider(
         @Path("provider") provider: String,
-        @Header("LinkToken") linkToken: String,
+        @Header("x-vital-link-token") linkToken: String,
     ): OauthLinkResponse
-
-    @POST("link/provider/manual/{provider}")
-    suspend fun manualProvider(
-        @Path("provider") provider: ManualProviderSlug,
-        @Body request: ManualProviderRequest,
-    ): ManualProviderResponse
 
     companion object {
         fun create(retrofit: Retrofit): LinkService {

--- a/VitalClient/src/main/java/io/tryvital/client/services/VitalClientExtension.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/VitalClientExtension.kt
@@ -21,9 +21,9 @@ suspend fun VitalClient.linkOAuthProvider(
     val token = linkService
         .createLink(CreateLinkRequest(userId, provider.toString(), callback))
 
-    val oauth = linkService.oauthProvider(
+    val oauth = linkService.linkOauthProvider(
         provider = provider.toString(),
-        linkToken = token.linkToken!!,
+        linkToken = token.linkToken,
     )
 
     withContext(Dispatchers.Main) {

--- a/VitalClient/src/main/java/io/tryvital/client/services/VitalPrivateService.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/VitalPrivateService.kt
@@ -1,7 +1,10 @@
 package io.tryvital.client.services
 
+import ManualProviderRequest
+import ManualProviderResponse
 import UserSDKSyncStateBody
 import UserSDKSyncStateResponse
+import io.tryvital.client.services.data.ManualProviderSlug
 import retrofit2.Retrofit
 import retrofit2.http.Body
 import retrofit2.http.POST
@@ -17,6 +20,13 @@ interface VitalPrivateService {
         @Path("user_id") userId: String,
         @Body body: UserSDKSyncStateBody
     ): UserSDKSyncStateResponse
+
+    @VitalPrivateApi
+    @POST("link/provider/manual/{provider}")
+    suspend fun manualProvider(
+        @Path("provider") provider: ManualProviderSlug,
+        @Body request: ManualProviderRequest,
+    ): ManualProviderResponse
 
     companion object {
         fun create(retrofit: Retrofit): VitalPrivateService {

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Link.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Link.kt
@@ -2,6 +2,7 @@ package io.tryvital.client.services.data
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import com.squareup.moshi.adapters.EnumJsonAdapter
 import io.tryvital.client.Region
 
 @JsonClass(generateAdapter = true)
@@ -14,31 +15,28 @@ data class CreateLinkRequest(
 )
 
 @JsonClass(generateAdapter = true)
-data class PasswordProviderRequest(
+data class LinkPasswordProviderInput(
     val username: String,
     val password: String,
-    @Json(name = "redirect_url")
-    val redirectUrl: String,
+    val region: String? = null,
 )
 
 @JsonClass(generateAdapter = true)
-data class EmailProviderRequest(
+data class CompletePasswordProviderMFAInput(
+    @Json(name = "mfa_code")
+    val mfaCode: String,
+)
+
+@JsonClass(generateAdapter = true)
+data class LinkEmailProviderInput(
     val email: String,
-    val region: Region,
-)
-
-@JsonClass(generateAdapter = true)
-data class ManualProviderRequest(
-    @Json(name = "user_id")
-    val userId: String,
-    @Json(name = "provider_id")
-    val providerId: String? = null,
+    val region: String? = null,
 )
 
 @JsonClass(generateAdapter = true)
 data class CreateLinkResponse(
     @Json(name = "link_token")
-    val linkToken: String?,
+    val linkToken: String,
 )
 
 @JsonClass(generateAdapter = true)
@@ -58,14 +56,49 @@ data class OauthLinkResponse(
 )
 
 @JsonClass(generateAdapter = true)
-data class EmailProviderResponse(
-    val success: Boolean,
+data class LinkResponse(
+    val state: State,
     @Json(name = "redirect_url")
-    val redirectUrl: String?,
-)
+    val redirectUrl: String? = null,
+    @Json(name = "error_type")
+    val errorType: String? = null,
+    val error: String? = null,
+    @Json(name = "provider_mfa")
+    val providerMFA: ProviderMFA? = null,
+) {
 
-@JsonClass(generateAdapter = true)
-data class ManualProviderResponse(
-    @Json(name = "success")
-    val success: Boolean,
-)
+    @JsonClass(generateAdapter = false)
+    enum class State {
+        @Json(name = "success")
+        Success,
+        @Json(name = "error")
+        Error,
+        @Json(name = "pending_provider_mfa")
+        PendingProviderMFA;
+
+        companion object {
+            val jsonAdapter: EnumJsonAdapter<State>
+                get() = EnumJsonAdapter.create(State::class.java)
+        }
+    }
+
+    @JsonClass(generateAdapter = true)
+    data class ProviderMFA(
+        val method: Method,
+        val hint: String,
+    ) {
+
+        @JsonClass(generateAdapter = false)
+        enum class Method {
+            @Json(name = "sms")
+            SMS,
+            @Json(name = "email")
+            Email;
+
+            companion object {
+                val jsonAdapter: EnumJsonAdapter<Method>
+                    get() = EnumJsonAdapter.create(Method::class.java)
+            }
+        }
+    }
+}

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/vitalPrivate.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/vitalPrivate.kt
@@ -42,3 +42,17 @@ data class UserSDKSyncStateResponse(
         append(")")
     }
 }
+
+@JsonClass(generateAdapter = true)
+data class ManualProviderRequest(
+    @Json(name = "user_id")
+    val userId: String,
+    @Json(name = "provider_id")
+    val providerId: String? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class ManualProviderResponse(
+    @Json(name = "success")
+    val success: Boolean,
+)

--- a/VitalClient/src/main/java/io/tryvital/client/userConnectedSources.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/userConnectedSources.kt
@@ -1,5 +1,7 @@
 package io.tryvital.client
 
+import ManualProviderRequest
+import io.tryvital.client.services.VitalPrivateApi
 import io.tryvital.client.services.data.*
 import retrofit2.HttpException
 
@@ -33,9 +35,10 @@ suspend fun VitalClient.createConnectedSourceIfNotExist(provider: ManualProvider
             .apply()
     }
 
+    @OptIn(VitalPrivateApi::class)
     try {
         // Remote Miss: Try to create the manual connected source.
-        linkService.manualProvider(
+        vitalPrivateService.manualProvider(
             provider = provider,
             request = ManualProviderRequest(userId = userId)
         )

--- a/VitalClient/src/test/java/io/tryvital/client/LinkServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/LinkServiceTest.kt
@@ -57,7 +57,7 @@ class LinkServiceTest {
         )
 
         val sut = LinkService.create(retrofit)
-        val oauthResponse = sut.oauthProvider(
+        val oauthResponse = sut.linkOauthProvider(
             provider = "strava",
             linkToken = linkToken
         )
@@ -78,17 +78,17 @@ class LinkServiceTest {
         )
 
         val sut = LinkService.create(retrofit)
-        val response = sut.emailProvider(
+        val response = sut.linkEmailProvider(
             provider = "strava",
             linkToken = linkToken,
-            request = EmailProviderRequest(
+            request = LinkEmailProviderInput(
                 email = "test@test.com",
-                region = Region.US,
+                region = "us",
             )
         )
 
         assertEquals("POST /link/provider/email/strava HTTP/1.1", server.takeRequest().requestLine)
-        assertTrue(response.success)
+        assertEquals(response.state, LinkResponse.State.Success)
         assertEquals("callback://vital", response.redirectUrl)
     }
 
@@ -101,13 +101,12 @@ class LinkServiceTest {
         )
 
         val sut = LinkService.create(retrofit)
-        val response = sut.passwordProvider(
+        val response = sut.linkPasswordProvider(
             provider = "strava",
             linkToken = linkToken,
-            request = PasswordProviderRequest(
+            request = LinkPasswordProviderInput(
                 username = "username",
                 password = "password",
-                redirectUrl = "callback://vital",
             )
         )
 
@@ -115,7 +114,7 @@ class LinkServiceTest {
             "POST /link/provider/password/strava HTTP/1.1",
             server.takeRequest().requestLine
         )
-        assertTrue(response.success)
+        assertEquals(response.state, LinkResponse.State.Success)
         assertEquals("callback://vital", response.redirectUrl)
     }
 
@@ -142,6 +141,6 @@ class LinkServiceTest {
 "id": 5
 }"""
 
-    private val fakeEmailLinkResponse = """{"success":true,"redirect_url":"callback://vital"}"""
+    private val fakeEmailLinkResponse = """{"state":"success","redirect_url":"callback://vital"}"""
 
 }


### PR DESCRIPTION
Changes:
* Link Password Provider & Link Email Provider typing
* Move manual provider creation to the VitalPrivateService namespace.

Addition:
* Complete Password Provider MFA