### PR TITLE
VIT-6624: Catch up with all API deprecations Pt.4

### DIFF
--- a/VitalClient/src/main/java/io/tryvital/client/userConnectedSources.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/userConnectedSources.kt
@@ -15,7 +15,7 @@ fun VitalClient.hasUserConnectedTo(provider: ProviderSlug): Boolean {
 }
 
 suspend fun VitalClient.createConnectedSourceIfNotExist(provider: ManualProviderSlug) {
-    val userId = checkUserId()
+    val userId = VitalClient.checkUserId()
     val slug = provider.toProviderSlug()
     if (hasUserConnectedTo(slug)) {
         // Local Hit: The client has witnessed a valid connected source for this provider before.
@@ -56,7 +56,7 @@ suspend fun VitalClient.createConnectedSourceIfNotExist(provider: ManualProvider
 }
 
 suspend fun VitalClient.userConnections(): List<UserConnection> {
-    val userId = checkUserId()
+    val userId = VitalClient.checkUserId()
     resetCachedUserConnectedSourceRecordIfNeeded()
 
     val response = userService.getUserConnections(userId = userId)

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
@@ -125,30 +125,6 @@ class VitalHealthConnectManager private constructor(
         setupSyncWorkerObservation()
     }
 
-    /**
-     * Stop any running task, and close this VitalHealthConnectManager instance.
-     *
-     * Note that this is not [cleanUp], which erases all SDK settings and persistent state.
-     */
-    @Suppress("unused")
-    fun close() {
-        taskScope.cancel()
-    }
-
-    /**
-     * Erase all SDK settings and persistent state for the current user.
-     *
-     * You typically only need to [cleanUp] when your application has logged out the current user.
-     */
-    @Deprecated(
-        "Use [VitalClient.signOut]. It resets both the Vital Core and Health SDKs."
-    )
-    @Suppress("unused")
-    fun cleanUp() {
-        @Suppress("DEPRECATION")
-        vitalClient.cleanUp()
-    }
-
     @OptIn(ExperimentalVitalApi::class)
     private fun resetAutoSync() {
         cancelSyncWorker()
@@ -506,18 +482,6 @@ class VitalHealthConnectManager private constructor(
                 HealthConnectClient.SDK_UNAVAILABLE_PROVIDER_UPDATE_REQUIRED -> HealthConnectAvailability.NotInstalled
                 else -> HealthConnectAvailability.NotSupportedSDK
             }
-        }
-
-        @Suppress("unused")
-        @Deprecated(
-            message="Use `openHealthConnectIntent(context)`.",
-            replaceWith = ReplaceWith(
-            "openHealthConnectIntent(context)?.let { context.startActivity(it) }",
-            "io.tryvital.vitalhealthconnect.VitalHealthConnectManager.Companion.openHealthConnectIntent"
-            )
-        )
-        fun openHealthConnect(context: Context) {
-            openHealthConnectIntent(context)?.let { context.startActivity(it) }
         }
 
         @Suppress("unused")

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncWorker.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncWorker.kt
@@ -207,7 +207,7 @@ internal class ResourceSyncWorker(appContext: Context, workerParams: WorkerParam
         timeZone: TimeZone
     ): UserSDKSyncStateResponse {
         val backendState = vitalClient.vitalPrivateService.healthConnectSdkSyncState(
-            vitalClient.checkUserId(),
+            VitalClient.checkUserId(),
             when (state) {
                 is ResourceSyncState.Historical -> UserSDKSyncStateBody(
                     stage = DataStage.Historical,
@@ -244,7 +244,7 @@ internal class ResourceSyncWorker(appContext: Context, workerParams: WorkerParam
         state: ResourceSyncState.Incremental,
         timeZone: TimeZone
     ) {
-        val userId = vitalClient.checkUserId()
+        val userId = VitalClient.checkUserId()
         val client = healthConnectClientProvider.getHealthConnectClient(applicationContext)
 
         val recordTypesToMonitor = recordTypesToMonitor().toSimpleNameSet()
@@ -323,7 +323,7 @@ internal class ResourceSyncWorker(appContext: Context, workerParams: WorkerParam
         end: Instant,
         timeZone: TimeZone
     ) {
-        val userId = vitalClient.checkUserId()
+        val userId = VitalClient.checkUserId()
         val client = healthConnectClientProvider.getHealthConnectClient(applicationContext)
 
         val recordTypesToMonitor = recordTypesToMonitor()


### PR DESCRIPTION
Remove:
* All deprecated SDK methods.

Move:
* VitalClient: instance method `checkUserId()` -> class method `checkUserId()`