### PR TITLE
VIT-6632: Caching SDK Sync State

### DIFF
--- a/VitalClient/src/main/java/io/tryvital/client/dependencies/Dependencies.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/dependencies/Dependencies.kt
@@ -19,6 +19,7 @@ import io.tryvital.client.services.data.ResourceAvailability
 import io.tryvital.client.services.data.SourceType
 import io.tryvital.client.services.data.VitalAPIResource
 import io.tryvital.client.utils.ApiKeyInterceptor
+import io.tryvital.client.utils.InstantJsonAdapter
 import io.tryvital.client.utils.VitalRequestInterceptor
 import io.tryvital.client.utils.LocalDateJsonAdapter
 import io.tryvital.client.utils.VitalLogger
@@ -31,6 +32,7 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 import java.lang.reflect.Type
 import java.text.DateFormat
 import java.text.SimpleDateFormat
+import java.time.Instant
 import java.time.LocalDate
 import java.util.*
 import java.util.concurrent.TimeUnit
@@ -102,6 +104,7 @@ internal class Dependencies(
 
         internal fun createMoshi(): Moshi = Moshi.Builder()
             .add(Date::class.java, Rfc3339DateJsonAdapter())
+            .add(Instant::class.java, InstantJsonAdapter)
             .add(LocalDate::class.java, LocalDateJsonAdapter)
             .add(ProviderSlug::class.java, ProviderSlug.jsonAdapter)
             .add(ManualProviderSlug::class.java, ManualProviderSlug.jsonAdapter)

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/vitalPrivate.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/vitalPrivate.kt
@@ -1,17 +1,17 @@
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import io.tryvital.client.services.data.DataStage
+import java.time.Instant
 import java.util.Date
 
 
 @JsonClass(generateAdapter = true)
 data class UserSDKSyncStateBody(
-    val stage: DataStage,
     val tzinfo: String,
     @Json(name = "request_start_date")
-    val requestStartDate: Date?,
+    val requestStartDate: Instant?,
     @Json(name = "request_end_date")
-    val requestEndDate: Date?,
+    val requestEndDate: Instant?,
 )
 
 @JsonClass(generateAdapter = false)
@@ -25,19 +25,23 @@ enum class UserSDKSyncStatus {
 data class UserSDKSyncStateResponse(
     val status: UserSDKSyncStatus,
     @Json(name = "request_start_date")
-    val requestStartDate: Date?,
+    val requestStartDate: Instant?,
     @Json(name = "request_end_date")
-    val requestEndDate: Date?,
+    val requestEndDate: Instant?,
+    @Json(name = "per_device_activity_ts")
+    val perDeviceActivityTS: Boolean = false,
+    @Json(name = "expires_in")
+    val expiresIn: Long = 14400,
 ) {
     override fun toString(): String = buildString {
-        append("(status=${status.name})")
+        append("(status=${status.name}, perDeviceActivityTs=$perDeviceActivityTS, expiresIn=$expiresIn")
         if (requestStartDate != null) {
             append(", start=")
-            append(requestStartDate.toInstant().toString())
+            append(requestStartDate.toString())
         }
         if (requestEndDate != null) {
             append(", end=")
-            append(requestEndDate.toInstant().toString())
+            append(requestEndDate.toString())
         }
         append(")")
     }

--- a/VitalClient/src/main/java/io/tryvital/client/utils/InstantJsonAdapter.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/utils/InstantJsonAdapter.kt
@@ -1,0 +1,26 @@
+package io.tryvital.client.utils
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import java.time.Instant
+
+object InstantJsonAdapter: JsonAdapter<Instant>() {
+    override fun fromJson(reader: JsonReader): Instant? {
+        if (reader.peek() == JsonReader.Token.NULL) {
+            return reader.nextNull()
+        }
+
+        val rawValue = reader.nextString()
+        return Instant.parse(rawValue)
+    }
+
+    override fun toJson(writer: JsonWriter, value: Instant?) {
+        if (value != null) {
+            writer.value(value.toString())
+        } else {
+            writer.nullValue()
+        }
+    }
+
+}

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/Utils.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/Utils.kt
@@ -16,6 +16,7 @@ object UnSecurePrefKeys {
     internal const val lastSeenWorkIdKey = "lastSeenWorkId"
     internal const val autoSyncThrottleKey = "autoSyncThrottle"
     internal const val backgroundSyncMinIntervalKey = "backgroundSyncMinInterval"
+    internal const val localSyncStateKey = "localSyncState"
 
     internal const val currentAskRequest = "currentAskRequest"
 

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/LocalSyncState.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/LocalSyncState.kt
@@ -1,0 +1,20 @@
+package io.tryvital.vitalhealthconnect.workers
+
+import com.squareup.moshi.JsonClass
+import io.tryvital.vitalhealthconnect.model.VitalResource
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+@JsonClass(generateAdapter = true)
+data class LocalSyncState(
+    val historicalStageAnchor: Instant,
+    val defaultDaysToBackfill: Long,
+    val ingestionEnd: Instant?,
+    val perDeviceActivityTS: Boolean,
+    val expiresAt: Instant,
+) {
+
+    fun historicalStartDate(@Suppress("UNUSED_PARAMETER") resource: VitalResource): Instant {
+        return historicalStageAnchor.minus(defaultDaysToBackfill, ChronoUnit.DAYS)
+    }
+}

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/LocalSyncStateManager.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/LocalSyncStateManager.kt
@@ -1,0 +1,105 @@
+package io.tryvital.vitalhealthconnect.workers
+
+import UserSDKSyncStateBody
+import android.content.SharedPreferences
+import io.tryvital.client.VitalClient
+import io.tryvital.client.createConnectedSourceIfNotExist
+import io.tryvital.client.services.VitalPrivateApi
+import io.tryvital.client.services.data.ManualProviderSlug
+import io.tryvital.client.utils.VitalLogger
+import io.tryvital.vitalhealthconnect.UnSecurePrefKeys
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.TimeZone
+
+internal class ConnectionPaused: Throwable()
+
+internal class LocalSyncStateManager(
+    private val vitalClient: VitalClient,
+    private val vitalLogger: VitalLogger,
+    private val preferences: SharedPreferences,
+) {
+
+    private fun getPersistedLocalSyncState(): LocalSyncState?
+        = preferences.getJson(UnSecurePrefKeys.localSyncStateKey)
+
+    private fun setPersistedLocalSyncState(newValue: LocalSyncState) {
+        preferences.edit()
+            .putJson(UnSecurePrefKeys.localSyncStateKey, newValue)
+            .apply()
+    }
+
+    @OptIn(VitalPrivateApi::class)
+    suspend fun getLocalSyncState(): LocalSyncState {
+        // If we have a LocalSyncState with valid TTL, return it.
+        val state = getPersistedLocalSyncState()
+        if (state != null && state.expiresAt > Instant.now()) {
+            return state
+        }
+
+        return localSyncStateMutex.withLock {
+            // Double check if a LocalSyncState could have already been computed by the previous
+            // lock holder.
+            val previousState = getPersistedLocalSyncState()
+            if (previousState != null && previousState.expiresAt > Instant.now()) {
+                return@withLock previousState
+            }
+
+            vitalLogger.info { "LocalSyncState: revalidating" }
+
+            /// Make sure the user has a connected source set up
+            vitalClient.createConnectedSourceIfNotExist(ManualProviderSlug.HealthConnect)
+
+            val now = Instant.now()
+            val numberOfDaysToBackfill = preferences.getInt(UnSecurePrefKeys.numberOfDaysToBackFillKey, 30).toLong()
+            val proposedStart = now.minus(numberOfDaysToBackfill, ChronoUnit.DAYS)
+            val backendState = vitalClient.vitalPrivateService.healthConnectSdkSyncState(
+                VitalClient.checkUserId(),
+                UserSDKSyncStateBody(
+                    tzinfo = TimeZone.getDefault().id,
+                    requestStartDate = proposedStart,
+                    requestEndDate = now,
+                )
+            )
+
+            if (backendState.status != UserSDKSyncStatus.Active) {
+                vitalLogger.info { "LocalSyncState: connection is paused" }
+                throw ConnectionPaused()
+            }
+
+            val newState = LocalSyncState(
+                // Historical start date is generally fixed once generated the first time, until signOut() reset.
+                //
+                // The only exception is if an ingestion start was set, in which case the most up-to-date
+                // ingestion start date takes precedence.
+                historicalStageAnchor = backendState.requestStartDate ?: previousState?.historicalStageAnchor ?: now,
+                defaultDaysToBackfill = previousState?.defaultDaysToBackfill ?: numberOfDaysToBackfill,
+
+                // The query upper bound (end date for historical & daily) is normally open-ended.
+                // In other words, `ingestionEnd` is typically nil.
+                //
+                // The only exception is if an ingestion end was set, in which case the most up-to-date
+                // ingestion end date dictates the query upper bound.
+                ingestionEnd = backendState.requestEndDate,
+
+                perDeviceActivityTS = backendState.perDeviceActivityTS,
+
+                // When we should revalidate the LocalSyncState again.
+                expiresAt = now.plusSeconds(backendState.expiresIn),
+            )
+
+            setPersistedLocalSyncState(newState)
+
+            vitalLogger.info { "LocalSyncState: updated; $newState" }
+
+            return@withLock newState
+        }
+    }
+
+
+    companion object {
+        internal val localSyncStateMutex = Mutex(false)
+    }
+}

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncStarter.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncStarter.kt
@@ -134,12 +134,6 @@ internal class ResourceSyncStarter(appContext: Context, workerParams: WorkerPara
                 .apply()
         }
 
-        // Before starting the sync, check that a connected source exists.
-        // This mirrors iOS SDK VitalHealthKitClient.syncData behaviour.
-        VitalClient.getOrCreate(applicationContext).run {
-            createConnectedSourceIfNotExist(ManualProviderSlug.HealthConnect)
-        }
-
         for (resource in input.resources) {
             val workRequest = OneTimeWorkRequestBuilder<ResourceSyncWorker>()
                 .setInputData(ResourceSyncWorkerInput(resource = resource).toData())


### PR DESCRIPTION
Mirror iOS SDK LocalSyncState + SyncInstruction + stage-less `/sdk_sync_state`, introduced in https://github.com/tryVital/vital-ios/pull/136

Also use Instant instead of Date in places being touched.