### PR TITLE
VIT-6636: Android: Honour the perDeviceActivityTs feature flag

### DIFF
--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
@@ -371,7 +371,8 @@ class VitalHealthConnectManager private constructor(
     suspend fun read(
         resource: VitalResource,
         startTime: Instant,
-        endTime: Instant
+        endTime: Instant,
+        processorOptions: ProcessorOptions = ProcessorOptions(),
     ): ProcessedResourceData {
         return readResourceByTimeRange(
             resource,
@@ -381,6 +382,7 @@ class VitalHealthConnectManager private constructor(
             currentDevice = Build.MODEL,
             reader = recordReader,
             processor = recordProcessor,
+            processorOptions = processorOptions,
         )
     }
 

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/processChangesResponse.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/processChangesResponse.kt
@@ -23,6 +23,7 @@ import io.tryvital.vitalhealthconnect.model.VitalResource
 import io.tryvital.vitalhealthconnect.model.processedresource.ProcessedResourceData
 import io.tryvital.vitalhealthconnect.model.processedresource.TimeSeriesData
 import io.tryvital.vitalhealthconnect.model.remapped
+import io.tryvital.vitalhealthconnect.records.ProcessorOptions
 import io.tryvital.vitalhealthconnect.records.RecordProcessor
 import io.tryvital.vitalhealthconnect.records.RecordReader
 import java.time.Instant
@@ -36,6 +37,7 @@ internal suspend fun processChangesResponse(
     currentDevice: String,
     reader: RecordReader,
     processor: RecordProcessor,
+    processorOptions: ProcessorOptions,
     end: Instant? = null,
 ): ProcessedResourceData {
     val records = responses.changes
@@ -66,6 +68,7 @@ internal suspend fun processChangesResponse(
             distance = records.get<DistanceRecord>().filter { it.endTime <= endAdjusted },
             steps = records.get<StepsRecord>().filter { it.endTime <= endAdjusted },
             vo2Max = records.get<Vo2MaxRecord>().filter { it.time <= endAdjusted },
+            options = processorOptions,
         ).let(ProcessedResourceData::Summary)
 
         VitalResource.Workout -> processor.processWorkoutsFromRecords(

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/readResource.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/readResource.kt
@@ -4,6 +4,7 @@ import io.tryvital.vitalhealthconnect.model.VitalResource
 import io.tryvital.vitalhealthconnect.model.processedresource.ProcessedResourceData
 import io.tryvital.vitalhealthconnect.model.processedresource.TimeSeriesData
 import io.tryvital.vitalhealthconnect.model.remapped
+import io.tryvital.vitalhealthconnect.records.ProcessorOptions
 import io.tryvital.vitalhealthconnect.records.RecordProcessor
 import io.tryvital.vitalhealthconnect.records.RecordReader
 import java.time.Instant
@@ -17,6 +18,7 @@ internal suspend fun readResourceByTimeRange(
     currentDevice: String,
     reader: RecordReader,
     processor: RecordProcessor,
+    processorOptions: ProcessorOptions,
 ): ProcessedResourceData {
     suspend fun <Record, T: TimeSeriesData> readTimeseries(
         read: suspend (Instant, Instant) -> List<Record>,
@@ -39,6 +41,7 @@ internal suspend fun readResourceByTimeRange(
             distance = reader.readDistance(startTime, endTime),
             steps = reader.readSteps(startTime, endTime),
             vo2Max = reader.readVo2Max(startTime, endTime),
+            options = processorOptions,
         ).let(ProcessedResourceData::Summary)
 
         VitalResource.Workout -> processor.processWorkoutsFromRecords(


### PR DESCRIPTION
Align Android SDK behaviour with iOS, where per-device activity timeseries is sent only if the team opts into the `sdk_per_device_activity_timeseries` feature flag.