### PR TITLE
VIT-6624: Catch up with API deprecations Pt.5

### DIFF
--- a/VitalClient/src/main/java/io/tryvital/client/dependencies/Dependencies.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/dependencies/Dependencies.kt
@@ -103,7 +103,6 @@ internal class Dependencies(
                 .build()
 
         internal fun createMoshi(): Moshi = Moshi.Builder()
-            .add(Date::class.java, Rfc3339DateJsonAdapter())
             .add(Instant::class.java, InstantJsonAdapter)
             .add(LocalDate::class.java, LocalDateJsonAdapter)
             .add(ProviderSlug::class.java, ProviderSlug.jsonAdapter)
@@ -141,25 +140,20 @@ internal class Dependencies(
             annotations: Array<out Annotation>,
             retrofit: Retrofit
         ): Converter<*, String>? {
-            return if (type === Date::class.java) {
-                DateQueryConverter.INSTANCE
+            return if (type === Instant::class.java) {
+                InstantQueryConverter.INSTANCE
             } else {
                 null
             }
         }
 
-        private class DateQueryConverter : Converter<Date, String> {
-            override fun convert(date: Date): String {
-                return DF.get()?.format(date) ?: "Error"
+        private class InstantQueryConverter : Converter<Instant, String> {
+            override fun convert(date: Instant): String {
+                return date.toString()
             }
 
             companion object {
-                val INSTANCE = DateQueryConverter()
-                private val DF: ThreadLocal<DateFormat> = object : ThreadLocal<DateFormat>() {
-                    public override fun initialValue(): DateFormat {
-                        return SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH)
-                    }
-                }
+                val INSTANCE = InstantQueryConverter()
             }
         }
 

--- a/VitalClient/src/main/java/io/tryvital/client/jwt/VitalJWTAuth.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/jwt/VitalJWTAuth.kt
@@ -10,6 +10,7 @@ import io.tryvital.client.Environment
 import io.tryvital.client.Region
 import io.tryvital.client.VITAL_ENCRYPTED_PERFS_FILE_NAME
 import io.tryvital.client.createEncryptedSharedPreferences
+import io.tryvital.client.utils.InstantJsonAdapter
 import io.tryvital.client.utils.VitalLogger
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.coroutineScope
@@ -39,7 +40,7 @@ const val AUTH_RECORD_KEY = "auth_record"
 
 private val moshi by lazy {
     Moshi.Builder()
-        .add(Date::class.java, Rfc3339DateJsonAdapter())
+        .add(Instant::class.java, InstantJsonAdapter)
         .build()
 }
 
@@ -168,7 +169,7 @@ internal class VitalJWTAuth(
                         publicApiKey = signInToken.publicKey,
                         accessToken = exchangeResponse.idToken,
                         refreshToken = exchangeResponse.refreshToken,
-                        expiry = Date.from(Instant.now().plusSeconds(exchangeResponse.expiresIn.toLong()))
+                        expiry = Instant.now().plusSeconds(exchangeResponse.expiresIn.toLong())
                     )
 
                     setRecord(newRecord, VitalJWTAuthChangeReason.SignedIn)
@@ -266,9 +267,7 @@ internal class VitalJWTAuth(
                         val newRecord = record.copy(
                             refreshToken = refreshResponse.refreshToken,
                             accessToken = refreshResponse.idToken,
-                            expiry = Date.from(
-                                Instant.now().plusSeconds(refreshResponse.expiresIn.toLong())
-                            ),
+                            expiry = Instant.now().plusSeconds(refreshResponse.expiresIn.toLong()),
                         )
 
                         setRecord(newRecord, VitalJWTAuthChangeReason.Update)
@@ -360,10 +359,10 @@ internal data class VitalJWTAuthRecord(
     val publicApiKey: String,
     val accessToken: String,
     val refreshToken: String,
-    val expiry: Date,
+    val expiry: Instant,
     val pendingReauthentication: Boolean = false,
 ) {
-    fun isExpired(now: Date = Date.from(Instant.now())) = expiry.before(now)
+    fun isExpired(now: Instant = Instant.now()) = expiry.isBefore(now)
 }
 
 @JsonClass(generateAdapter = true)

--- a/VitalClient/src/main/java/io/tryvital/client/services/ActivityService.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/ActivityService.kt
@@ -3,6 +3,7 @@ package io.tryvital.client.services
 import io.tryvital.client.services.data.*
 import retrofit2.Retrofit
 import retrofit2.http.*
+import java.time.Instant
 import java.util.*
 
 @Suppress("unused")
@@ -13,16 +14,16 @@ interface ActivityService {
     @GET("summary/activity/{user_id}")
     suspend fun getActivity(
         @Path("user_id") userId: String,
-        @Query("start_date") startDate: Date,
-        @Query("end_date") endDate: Date?,
+        @Query("start_date") startDate: Instant,
+        @Query("end_date") endDate: Instant?,
         @Query("provider") provider: String?,
     ): ActivitiesResponse
 
     @GET("summary/activity/{user_id}/raw")
     suspend fun getActivityRaw(
         @Path("user_id") userId: String,
-        @Query("start_date") startDate: Date,
-        @Query("end_date") endDate: Date?,
+        @Query("start_date") startDate: Instant,
+        @Query("end_date") endDate: Instant?,
         @Query("provider") provider: String?,
     ): Any
 

--- a/VitalClient/src/main/java/io/tryvital/client/services/BodyService.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/BodyService.kt
@@ -5,6 +5,7 @@ import retrofit2.Retrofit
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
+import java.time.Instant
 import java.util.*
 
 @Suppress("unused")
@@ -13,8 +14,8 @@ interface BodyService {
     @GET("summary/body/{user_id}")
     suspend fun getBodyData(
         @Path("user_id") userId: String,
-        @Query("start_date") startDate: Date,
-        @Query("end_date") endDate: Date?,
+        @Query("start_date") startDate: Instant,
+        @Query("end_date") endDate: Instant?,
         @Query("provider") provider: String?,
     ): BodyDataResponse
 

--- a/VitalClient/src/main/java/io/tryvital/client/services/SleepService.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/SleepService.kt
@@ -5,6 +5,7 @@ import retrofit2.Retrofit
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
+import java.time.Instant
 import java.util.*
 
 @Suppress("unused")
@@ -13,8 +14,8 @@ interface SleepService {
     @GET("summary/sleep/{user_id}")
     suspend fun getSleepData(
         @Path("user_id") userId: String,
-        @Query("start_date") startDate: Date,
-        @Query("end_date") endDate: Date?,
+        @Query("start_date") startDate: Instant,
+        @Query("end_date") endDate: Instant?,
         @Query("provider") provider: String?,
     ): SleepResponse
 
@@ -22,16 +23,16 @@ interface SleepService {
     @GET("summary/sleep/{user_id}/stream")
     suspend fun getSleepStreamSeries(
         @Path("user_id") userId: String,
-        @Query("start_date") startDate: Date,
-        @Query("end_date") endDate: Date?,
+        @Query("start_date") startDate: Instant,
+        @Query("end_date") endDate: Instant?,
         @Query("provider") provider: String?,
     ): SleepResponse
 
     @GET("summary/sleep/{user_id}/raw")
     suspend fun getSleepDataRaw(
         @Path("user_id") userId: String,
-        @Query("start_date") startDate: Date,
-        @Query("end_date") endDate: Date?,
+        @Query("start_date") startDate: Instant,
+        @Query("end_date") endDate: Instant?,
         @Query("provider") provider: String?,
     ): Any
 

--- a/VitalClient/src/main/java/io/tryvital/client/services/VitalsService.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/VitalsService.kt
@@ -4,6 +4,7 @@ import io.tryvital.client.services.data.*
 import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.http.*
+import java.time.Instant
 import java.util.*
 
 @Suppress("unused")
@@ -11,8 +12,8 @@ class VitalsService private constructor(private val timeSeries: TimeSeries) {
 
     suspend fun getGlucose(
         userId: String,
-        startDate: Date,
-        endDate: Date? = null,
+        startDate: Instant,
+        endDate: Instant? = null,
         provider: String? = null,
         cursor: String? = null,
     ): GroupedSamplesResponse<ScalarSample> {
@@ -25,8 +26,8 @@ class VitalsService private constructor(private val timeSeries: TimeSeries) {
     suspend fun getCholesterol(
         cholesterolType: CholesterolType,
         userId: String,
-        startDate: Date,
-        endDate: Date? = null,
+        startDate: Instant,
+        endDate: Instant? = null,
         provider: String? = null,
         cursor: String? = null,
     ): GroupedSamplesResponse<ScalarSample> {
@@ -42,8 +43,8 @@ class VitalsService private constructor(private val timeSeries: TimeSeries) {
 
     suspend fun getIge(
         userId: String,
-        startDate: Date,
-        endDate: Date? = null,
+        startDate: Instant,
+        endDate: Instant? = null,
         provider: String? = null,
         cursor: String? = null,
     ): GroupedSamplesResponse<ScalarSample> {
@@ -59,8 +60,8 @@ class VitalsService private constructor(private val timeSeries: TimeSeries) {
 
     suspend fun getIgg(
         userId: String,
-        startDate: Date,
-        endDate: Date? = null,
+        startDate: Instant,
+        endDate: Instant? = null,
         provider: String? = null,
         cursor: String? = null,
     ): GroupedSamplesResponse<ScalarSample> {
@@ -76,8 +77,8 @@ class VitalsService private constructor(private val timeSeries: TimeSeries) {
 
     suspend fun getHeartrate(
         userId: String,
-        startDate: Date,
-        endDate: Date? = null,
+        startDate: Instant,
+        endDate: Instant? = null,
         provider: String? = null,
         cursor: String? = null,
     ): GroupedSamplesResponse<ScalarSample> {
@@ -126,8 +127,8 @@ private interface TimeSeries {
     suspend fun scalarSampleTimeseriesRequest(
         @Path("user_id") userId: String,
         @Path("resource", encoded = true) resource: String,
-        @Query("start_date") startDate: Date,
-        @Query("end_date") endDate: Date? = null,
+        @Query("start_date") startDate: Instant,
+        @Query("end_date") endDate: Instant? = null,
         @Query("provider") provider: String? = null,
         @Query("cursor") cursor: String? = null,
     ): GroupedSamplesResponse<ScalarSample>

--- a/VitalClient/src/main/java/io/tryvital/client/services/WorkoutService.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/WorkoutService.kt
@@ -6,6 +6,7 @@ import retrofit2.Retrofit
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
+import java.time.Instant
 import java.util.*
 
 @Suppress("unused")
@@ -13,16 +14,16 @@ interface WorkoutService {
     @GET("summary/workouts/{user_id}")
     suspend fun getWorkouts(
         @Path("user_id") userId: String,
-        @Query("start_date") startDate: Date,
-        @Query("end_date") endDate: Date?,
+        @Query("start_date") startDate: Instant,
+        @Query("end_date") endDate: Instant?,
         @Query("provider") provider: String?,
     ): WorkoutsResponse
 
     @GET("summary/workouts/{user_id}/raw")
     suspend fun getWorkoutsRaw(
         @Path("user_id") userId: String,
-        @Query("start_date") startDate: Date,
-        @Query("end_date") endDate: Date?,
+        @Query("start_date") startDate: Instant,
+        @Query("end_date") endDate: Instant?,
         @Query("provider") provider: String?,
     ): Any
 

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Measurement.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Measurement.kt
@@ -2,11 +2,12 @@ package io.tryvital.client.services.data
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import java.time.Instant
 import java.util.*
 
 @JsonClass(generateAdapter = true)
 data class ScalarSample(
-    val timestamp: Date,
+    val timestamp: Instant,
     val value: Double,
     val type: String?,
     val unit: String,
@@ -16,8 +17,8 @@ data class ScalarSample(
 
 @JsonClass(generateAdapter = true)
 data class IntervalSample(
-    val start: Date,
-    val end: Date,
+    val start: Instant,
+    val end: Instant,
     val value: Double,
     val type: String?,
     val unit: String,
@@ -27,7 +28,7 @@ data class IntervalSample(
 
 @JsonClass(generateAdapter = true)
 data class BloodPressureSample(
-    val timestamp: Date,
+    val timestamp: Instant,
     val systolic: Double?,
     val diastolic: Double?,
     val type: String?,

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Sleep.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Sleep.kt
@@ -2,6 +2,7 @@ package io.tryvital.client.services.data
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import java.time.Instant
 import java.util.*
 
 @JsonClass(generateAdapter = true)
@@ -19,9 +20,9 @@ data class SleepData(
     @Json(name = "calendar_date")
     val calendarDate: String,
     @Json(name = "bedtime_start")
-    val bedtimeStart: Date?,
+    val bedtimeStart: Instant?,
     @Json(name = "bedtime_stop")
-    val bedtimeStop: Date?,
+    val bedtimeStop: Instant?,
     @Json(name = "timezone_offset")
     val timezoneOffset: Int?,
     val duration: Int?,

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Summary.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Summary.kt
@@ -2,6 +2,7 @@ package io.tryvital.client.services.data
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import java.time.Instant
 import java.util.*
 
 @JsonClass(generateAdapter = true)
@@ -11,9 +12,9 @@ data class SummaryPayload<T>(
     @Json(name = "provider")
     val provider: ManualProviderSlug,
     @Json(name = "start_date")
-    val startDate: Date?,
+    val startDate: Instant?,
     @Json(name = "end_date")
-    val endDate: Date?,
+    val endDate: Instant?,
     @Json(name = "time_zone")
     val timeZoneId: String?,
     @Json(name = "data")
@@ -25,9 +26,9 @@ data class WorkoutPayload(
     @Json(name = "id")
     val id: String,
     @Json(name = "start_date")
-    val startDate: Date,
+    val startDate: Instant,
     @Json(name = "end_date")
-    val endDate: Date,
+    val endDate: Instant,
     @Json(name = "source_bundle")
     val sourceBundle: String?,
     @Json(name = "product_type")
@@ -65,11 +66,11 @@ data class ActivityPayload(
 @JsonClass(generateAdapter = true)
 data class ProfilePayload(
     @Json(name = "biological_sex")
-    val biologicalSex: String,
+    val biologicalSex: String?,
     @Json(name = "date_of_birth")
-    val dateOfBirth: Date,
+    val dateOfBirth: Instant?,
     @Json(name = "height")
-    val heightInCm: Int,
+    val heightInCm: Int?,
 )
 
 @JsonClass(generateAdapter = true)
@@ -85,9 +86,9 @@ data class SleepPayload(
     @Json(name = "id")
     val id: String,
     @Json(name = "start_date")
-    val startDate: Date,
+    val startDate: Instant,
     @Json(name = "end_date")
-    val endDate: Date,
+    val endDate: Instant,
     @Json(name = "source_bundle")
     val sourceBundle: String?,
     @Json(name = "product_type")
@@ -113,9 +114,9 @@ data class QuantitySamplePayload(
     @Json(name = "unit")
     val unit: String,
     @Json(name = "start_date")
-    val startDate: Date,
+    val startDate: Instant,
     @Json(name = "end_date")
-    val endDate: Date,
+    val endDate: Instant,
     @Json(name = "source_bundle")
     val sourceBundle: String? = null,
     @Json(name = "product_type")

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Timeseries.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Timeseries.kt
@@ -3,6 +3,7 @@ package io.tryvital.client.services.data
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import io.tryvital.client.utils.getJsonName
+import java.time.Instant
 import java.util.*
 
 @JsonClass(generateAdapter = true)
@@ -12,9 +13,9 @@ data class TimeseriesPayload<T> (
     @Json(name = "provider")
     val provider: ManualProviderSlug,
     @Json(name = "start_date")
-    val startDate: Date?,
+    val startDate: Instant?,
     @Json(name = "end_date")
-    val endDate: Date?,
+    val endDate: Instant?,
     @Json(name = "time_zone")
     val timeZoneId: String?,
     @Json(name = "data")

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/User.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/User.kt
@@ -3,6 +3,7 @@ package io.tryvital.client.services.data
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.adapters.EnumJsonAdapter
+import java.time.Instant
 import java.util.*
 
 @JsonClass(generateAdapter = true)
@@ -14,7 +15,7 @@ data class User(
     @Json(name = "client_user_id")
     val clientUserId: String,
     @Json(name = "created_on")
-    val createdOn: Date,
+    val createdOn: Instant,
 )
 
 @JsonClass(generateAdapter = true)

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Workout.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Workout.kt
@@ -2,6 +2,7 @@ package io.tryvital.client.services.data
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import java.time.Instant
 import java.util.*
 
 @JsonClass(generateAdapter = true)
@@ -27,9 +28,9 @@ data class Workout(
     val maxHr: Double?,
     val distance: Double?,
     @Json(name = "time_start")
-    val timeStart: Date?,
+    val timeStart: Instant?,
     @Json(name = "time_end")
-    val timeEnd: Date?,
+    val timeEnd: Instant?,
     val calories: Double?,
     val sport: Sport?,
     @Json(name = "hr_zones")

--- a/VitalClient/src/test/java/io/tryvital/client/ActivityServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/ActivityServiceTest.kt
@@ -14,6 +14,7 @@ import org.junit.Before
 import org.junit.Test
 import retrofit2.Retrofit
 import java.text.SimpleDateFormat
+import java.time.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ActivityServiceTest {
@@ -35,16 +36,15 @@ class ActivityServiceTest {
                 .setResponseCode(200)
                 .setBody(fakeActivityResponse)
         )
-        val dateFormat = SimpleDateFormat("yyyy-MM-dd")
         val sut = ActivityService.create(retrofit)
         val response = sut.getActivity(
             userId = userId,
-            startDate = dateFormat.parse("2022-07-01")!!,
-            endDate = dateFormat.parse("2022-07-21"),
+            startDate = Instant.parse("2022-07-01T00:00:00Z")!!,
+            endDate = Instant.parse("2022-07-21T00:00:00Z"),
             provider = null
         )
         assertEquals(
-            "GET /summary/activity/$userId?start_date=2022-07-01&end_date=2022-07-21 HTTP/1.1",
+            "GET /summary/activity/$userId?start_date=2022-07-01T00%3A00%3A00Z&end_date=2022-07-21T00%3A00%3A00Z HTTP/1.1",
             server.takeRequest().requestLine
         )
 

--- a/VitalClient/src/test/java/io/tryvital/client/BodyServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/BodyServiceTest.kt
@@ -15,6 +15,7 @@ import org.junit.Before
 import org.junit.Test
 import retrofit2.Retrofit
 import java.text.SimpleDateFormat
+import java.time.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class BodyServiceTest {
@@ -36,16 +37,15 @@ class BodyServiceTest {
                 .setResponseCode(200)
                 .setBody(fakeBodyResponse)
         )
-        val dateFormat = SimpleDateFormat("yyyy-MM-dd")
         val sut = BodyService.create(retrofit)
         val response = sut.getBodyData(
             userId = userId,
-            startDate = dateFormat.parse("2022-07-01")!!,
-            endDate = dateFormat.parse("2022-07-21"),
+            startDate = Instant.parse("2022-07-01T00:00:00Z")!!,
+            endDate = Instant.parse("2022-07-21T00:00:00Z"),
             provider = null
         )
         assertEquals(
-            "GET /summary/body/$userId?start_date=2022-07-01&end_date=2022-07-21 HTTP/1.1",
+            "GET /summary/body/$userId?start_date=2022-07-01T00%3A00%3A00Z&end_date=2022-07-21T00%3A00%3A00Z HTTP/1.1",
             server.takeRequest().requestLine
         )
 

--- a/VitalClient/src/test/java/io/tryvital/client/SleepServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/SleepServiceTest.kt
@@ -14,6 +14,7 @@ import org.junit.Before
 import org.junit.Test
 import retrofit2.Retrofit
 import java.text.SimpleDateFormat
+import java.time.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SleepServiceTest {
@@ -35,16 +36,15 @@ class SleepServiceTest {
                 .setResponseCode(200)
                 .setBody(fakeSleepDataResponse)
         )
-        val dateFormat = SimpleDateFormat("yyyy-MM-dd")
         val sut = SleepService.create(retrofit)
         val response = sut.getSleepData(
             userId = userId,
-            startDate = dateFormat.parse("2022-07-01")!!,
-            endDate = dateFormat.parse("2022-07-21"),
+            startDate = Instant.parse("2022-07-01T00:00:00Z")!!,
+            endDate = Instant.parse("2022-07-21T00:00:00Z"),
             provider = null
         )
         assertEquals(
-            "GET /summary/sleep/$userId?start_date=2022-07-01&end_date=2022-07-21 HTTP/1.1",
+            "GET /summary/sleep/$userId?start_date=2022-07-01T00%3A00%3A00Z&end_date=2022-07-21T00%3A00%3A00Z HTTP/1.1",
             server.takeRequest().requestLine
         )
 

--- a/VitalClient/src/test/java/io/tryvital/client/SummaryServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/SummaryServiceTest.kt
@@ -48,8 +48,8 @@ class SummaryServiceTest {
                 data = listOf(
                     WorkoutPayload(
                         id = "test raw supersize",
-                        startDate = Date.from(Instant.parse("2007-01-01T00:00:00.00Z")),
-                        endDate = Date.from(Instant.parse("2007-01-05T00:00:00.00Z")),
+                        startDate = Instant.parse("2007-01-01T00:00:00.00Z"),
+                        endDate = Instant.parse("2007-01-05T00:00:00.00Z"),
                         sourceBundle = "fit",
                         deviceModel = "not Iphone",
                         sport = "walking",
@@ -83,7 +83,7 @@ class SummaryServiceTest {
                 timeZoneId = null,
                 data = ProfilePayload(
                     biologicalSex = "not_set",
-                    dateOfBirth = Date(0),
+                    dateOfBirth = null,
                     heightInCm = 188,
                 )
             )

--- a/VitalClient/src/test/java/io/tryvital/client/VitalsServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/VitalsServiceTest.kt
@@ -37,7 +37,6 @@ class VitalsServiceTest {
     @Test
     fun `Get cholesterol`() = runTest {
 
-        val dateFormat = SimpleDateFormat("yyyy-MM-dd")
         val sut = VitalsService.create(retrofit)
         for (type in CholesterolType.values()) {
             server.enqueue(
@@ -46,12 +45,12 @@ class VitalsServiceTest {
             val response = sut.getCholesterol(
                 cholesterolType = type,
                 userId = userId,
-                startDate = dateFormat.parse("2022-07-01")!!,
-                endDate = dateFormat.parse("2022-07-21"),
+                startDate = Instant.parse("2022-07-01T00:00:00Z")!!,
+                endDate = Instant.parse("2022-07-21T00:00:00Z"),
                 provider = null
             )
             assertEquals(
-                "GET /timeseries/$userId/cholesterol/${type.name}?start_date=2022-07-01&end_date=2022-07-21 HTTP/1.1",
+                "GET /timeseries/$userId/cholesterol/${type.name}?start_date=2022-07-01T00%3A00%3A00Z&end_date=2022-07-21T00%3A00%3A00Z HTTP/1.1",
                 server.takeRequest().requestLine
             )
             checkMeasurements(response)
@@ -63,16 +62,15 @@ class VitalsServiceTest {
         server.enqueue(
             MockResponse().setResponseCode(200).setBody(fakeScalarSampleResponse)
         )
-        val dateFormat = SimpleDateFormat("yyyy-MM-dd")
         val sut = VitalsService.create(retrofit)
         val response = sut.getGlucose(
             userId = userId,
-            startDate = dateFormat.parse("2022-07-01")!!,
-            endDate = dateFormat.parse("2022-07-21"),
+            startDate = Instant.parse("2022-07-01T00:00:00Z")!!,
+            endDate = Instant.parse("2022-07-21T00:00:00Z"),
             provider = null
         )
         assertEquals(
-            "GET /timeseries/$userId/glucose?start_date=2022-07-01&end_date=2022-07-21 HTTP/1.1",
+            "GET /timeseries/$userId/glucose?start_date=2022-07-01T00%3A00%3A00Z&end_date=2022-07-21T00%3A00%3A00Z HTTP/1.1",
             server.takeRequest().requestLine
         )
         checkMeasurements(response)
@@ -84,13 +82,13 @@ class VitalsServiceTest {
                 GroupedSamples(
                     data = listOf(
                         ScalarSample(
-                            timestamp = Date.from(Instant.parse("2022-01-01T03:16:31+00:00")),
+                            timestamp = Instant.parse("2022-01-01T03:16:31+00:00"),
                             value = 5.7,
                             type = null,
                             unit = "count",
                         ),
                         ScalarSample(
-                            timestamp = Date.from(Instant.parse("2022-01-02T03:16:32+00:00")),
+                            timestamp = Instant.parse("2022-01-02T03:16:32+00:00"),
                             value = 10.2,
                             type = null,
                             unit = "count",

--- a/VitalClient/src/test/java/io/tryvital/client/WorkoutServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/WorkoutServiceTest.kt
@@ -14,6 +14,7 @@ import org.junit.Before
 import org.junit.Test
 import retrofit2.Retrofit
 import java.text.SimpleDateFormat
+import java.time.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class WorkoutServiceTest {
@@ -33,16 +34,15 @@ class WorkoutServiceTest {
         server.enqueue(
             MockResponse().setResponseCode(200).setBody(fakeWorkoutsResponse)
         )
-        val dateFormat = SimpleDateFormat("yyyy-MM-dd")
         val sut = WorkoutService.create(retrofit)
         val response = sut.getWorkouts(
             userId = userId,
-            startDate = dateFormat.parse("2022-07-01")!!,
-            endDate = dateFormat.parse("2022-07-21"),
+            startDate = Instant.parse("2022-07-01T00:00:00Z")!!,
+            endDate = Instant.parse("2022-07-21T00:00:00Z"),
             provider = null
         )
         assertEquals(
-            "GET /summary/workouts/$userId?start_date=2022-07-01&end_date=2022-07-21 HTTP/1.1",
+            "GET /summary/workouts/$userId?start_date=2022-07-01T00%3A00%3A00Z&end_date=2022-07-21T00%3A00%3A00Z HTTP/1.1",
             server.takeRequest().requestLine
         )
         val workout1 = response.workouts[0]

--- a/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/BloodPressureReader1810.kt
+++ b/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/BloodPressureReader1810.kt
@@ -40,8 +40,8 @@ class BloodPressureReader1810(
 
         // We accept only stored Blood Pressure records with a timestamp (as suggested by BLE Blood
         // Pressure Service specification v1.1.1).
-        val measurementTime = response.timestamp?.time ?: return null
-        val idPrefix = "${measurementTime.time / 1000}-"
+        val measurementTime = response.timestamp?.time?.toInstant() ?: return null
+        val idPrefix = "${measurementTime.epochSecond}-"
 
         return BloodPressureSample(
             systolic = QuantitySamplePayload(

--- a/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/GlucoseMeter1808.kt
+++ b/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/GlucoseMeter1808.kt
@@ -42,7 +42,7 @@ class GlucoseMeter1808(
 
         // A compliant record should have a value and a timestamp.
         val glucoseConcentration = response.glucoseConcentration ?: return null
-        val measurementTime = response.time?.time ?: return null
+        val measurementTime = response.time?.time?.toInstant() ?: return null
 
         val (value, sampleType) = when (response.unit) {
             UNIT_mol_L ->
@@ -55,7 +55,7 @@ class GlucoseMeter1808(
         return QuantitySamplePayload(
             // Prefixed with epoch in seconds to avoid sequence number conflicts
             // (due to new device and/or device reset)
-            id = "${measurementTime.time / 1000}-${response.sequenceNumber}",
+            id = "${measurementTime.epochSecond}-${response.sequenceNumber}",
             value = value,
             unit = sampleType.unit,
             startDate = measurementTime,

--- a/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/Libre1Reader.kt
+++ b/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/Libre1Reader.kt
@@ -93,8 +93,8 @@ private fun quantitySampleFromGlucose(glucose: Glucose): QuantitySamplePayload {
     return QuantitySamplePayload(
         id = glucose.id.toString(),
         value = glucose.valueUnit,
-        startDate = Date.from(glucose.date),
-        endDate = Date.from(glucose.date),
+        startDate = glucose.date,
+        endDate = glucose.date,
         type = "manual_scan",
         unit = "mmol/L",
     )

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/HCQuantitySample.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/HCQuantitySample.kt
@@ -2,13 +2,14 @@ package io.tryvital.vitalhealthconnect.model
 
 import androidx.health.connect.client.records.metadata.Metadata
 import io.tryvital.vitalhealthconnect.model.processedresource.QuantitySample
+import java.time.Instant
 import java.util.Date
 
 data class HCQuantitySample(
     val value: Double,
     val unit: String,
-    val startDate: Date,
-    val endDate: Date,
+    val startDate: Instant,
+    val endDate: Instant,
     val type: String? = null,
     val metadata: Metadata,
 ) {

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/ProcessedResourceData.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/ProcessedResourceData.kt
@@ -3,6 +3,7 @@ package io.tryvital.vitalhealthconnect.model.processedresource
 import io.tryvital.client.services.data.BodyPayload
 import io.tryvital.client.services.data.IngestibleTimeseriesResource
 import io.tryvital.client.services.data.ProfilePayload
+import java.time.Instant
 import java.util.Date
 
 sealed class ProcessedResourceData {
@@ -55,9 +56,9 @@ sealed class SummaryData {
     abstract fun isNotEmpty(): Boolean
 
     data class Profile(
-        val biologicalSex: String,
-        val dateOfBirth: Date,
-        val heightInCm: Int,
+        val biologicalSex: String?,
+        val dateOfBirth: Instant?,
+        val heightInCm: Int?,
     ) : SummaryData() {
 
         fun toProfilePayload(): ProfilePayload {

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/QuantitySample.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/QuantitySample.kt
@@ -1,14 +1,15 @@
 package io.tryvital.vitalhealthconnect.model.processedresource
 
 import io.tryvital.client.services.data.QuantitySamplePayload
+import java.time.Instant
 import java.util.Date
 
 data class QuantitySample(
     val id: String? = null,
     val value: Double,
     val unit: String,
-    val startDate: Date,
-    val endDate: Date,
+    val startDate: Instant,
+    val endDate: Instant,
     val sourceBundle: String? = null,
     val deviceModel: String? = null,
     val type: String? = null,

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/Sleep.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/Sleep.kt
@@ -1,12 +1,13 @@
 package io.tryvital.vitalhealthconnect.model.processedresource
 
 import io.tryvital.client.services.data.SleepPayload
+import java.time.Instant
 import java.util.Date
 
 data class Sleep(
     val id: String,
-    val startDate: Date,
-    val endDate: Date,
+    val startDate: Instant,
+    val endDate: Instant,
     val sourceBundle: String?,
     val deviceModel: String?,
     val heartRate: List<QuantitySample>,

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/Workout.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/Workout.kt
@@ -1,12 +1,13 @@
 package io.tryvital.vitalhealthconnect.model.processedresource
 
 import io.tryvital.client.services.data.WorkoutPayload
+import java.time.Instant
 import java.util.Date
 
 data class Workout(
     val id: String,
-    val startDate: Date,
-    val endDate: Date,
+    val startDate: Instant,
+    val endDate: Instant,
     val sourceBundle: String?,
     val deviceModel: String?,
     val sport: String,

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordProcessor.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordProcessor.kt
@@ -130,15 +130,15 @@ internal class HealthConnectRecordProcessor(
                     systolic = HCQuantitySample(
                         value = it.systolic.inMillimetersOfMercury,
                         unit = SampleType.BloodPressureSystolic.unit,
-                        startDate = Date.from(it.time),
-                        endDate = Date.from(it.time),
+                        startDate = it.time,
+                        endDate = it.time,
                         metadata = it.metadata,
                     ).toQuantitySample(currentDevice),
                     diastolic = HCQuantitySample(
                         value = it.diastolic.inMillimetersOfMercury,
                         unit = SampleType.BloodPressureDiastolic.unit,
-                        startDate = Date.from(it.time),
-                        endDate = Date.from(it.time),
+                        startDate = it.time,
+                        endDate = it.time,
                         metadata = it.metadata,
                     ).toQuantitySample(currentDevice),
                     pulse = null,
@@ -157,8 +157,8 @@ internal class HealthConnectRecordProcessor(
                 HCQuantitySample(
                     value = it.level.inMilligramsPerDeciliter,
                     unit = SampleType.GlucoseConcentrationMilligramPerDecilitre.unit,
-                    startDate = Date.from(it.time),
-                    endDate = Date.from(it.time),
+                    startDate = it.time,
+                    endDate = it.time,
                     metadata = it.metadata,
                 ).toQuantitySample(currentDevice)
             })
@@ -184,8 +184,8 @@ internal class HealthConnectRecordProcessor(
                 HCQuantitySample(
                     value = it.heartRateVariabilityMillis,
                     unit = SampleType.HeartRateVariabilityRmssd.unit,
-                    startDate = Date.from(it.time),
-                    endDate = Date.from(it.time),
+                    startDate = it.time,
+                    endDate = it.time,
                     metadata = it.metadata,
                 ).toQuantitySample(currentDevice)
             }
@@ -203,8 +203,8 @@ internal class HealthConnectRecordProcessor(
                 HCQuantitySample(
                     value = it.volume.inMilliliters,
                     unit = SampleType.Water.unit,
-                    startDate = Date.from(it.startTime),
-                    endDate = Date.from(it.endTime),
+                    startDate = it.startTime,
+                    endDate = it.endTime,
                     metadata = it.metadata,
                 ).toQuantitySample(currentDevice)
             }
@@ -226,8 +226,8 @@ internal class HealthConnectRecordProcessor(
 
                 Workout(
                     id = exercise.metadata.id,
-                    startDate = Date.from(exercise.startTime),
-                    endDate = Date.from(exercise.endTime),
+                    startDate = exercise.startTime,
+                    endDate = exercise.endTime,
                     sourceBundle = exercise.metadata.dataOrigin.packageName,
                     sport = EXERCISE_TYPE_INT_TO_STRING_MAP[exercise.exerciseType] ?: "workout",
                     caloriesInKiloJules = summary.caloriesBurned,
@@ -251,7 +251,7 @@ internal class HealthConnectRecordProcessor(
     ) =
         SummaryData.Profile(
             biologicalSex = "not_set", // this is not available in Health Connect
-            dateOfBirth = Date(0), // this is not available in Health Connect
+            dateOfBirth = null, // this is not available in Health Connect
             heightInCm = (heightRecords.lastOrNull()?.height?.inMeters?.times(100))?.roundToInt()
                 ?: 0,
         )
@@ -265,8 +265,8 @@ internal class HealthConnectRecordProcessor(
             HCQuantitySample(
                 value = it.weight.inKilograms,
                 unit = SampleType.Weight.unit,
-                startDate = Date.from(it.time),
-                endDate = Date.from(it.time),
+                startDate = it.time,
+                endDate = it.time,
                 metadata = it.metadata,
             ).toQuantitySample(fallbackDeviceModel)
         },
@@ -274,8 +274,8 @@ internal class HealthConnectRecordProcessor(
             HCQuantitySample(
                 value = it.percentage.value,
                 unit = SampleType.BodyFat.unit,
-                startDate = Date.from(it.time),
-                endDate = Date.from(it.time),
+                startDate = it.time,
+                endDate = it.time,
                 metadata = it.metadata,
             ).toQuantitySample(fallbackDeviceModel)
         }
@@ -311,8 +311,8 @@ internal class HealthConnectRecordProcessor(
 
             Sleep(
                 id = sleepSession.metadata.id,
-                startDate = Date.from(sleepSession.startTime),
-                endDate = Date.from(sleepSession.endTime),
+                startDate = sleepSession.startTime,
+                endDate = sleepSession.endTime,
                 sourceBundle = sleepSession.metadata.dataOrigin.packageName,
                 deviceModel = fallbackDeviceModel,
                 heartRate = mapHearthRate(heartRateRecord, fallbackDeviceModel),
@@ -335,8 +335,8 @@ internal class HealthConnectRecordProcessor(
                             QuantitySample(
                                 value = SleepStage.Awake.id.toDouble(),
                                 unit = "stage",
-                                startDate = Date.from(sleepStage.startTime),
-                                endDate = Date.from(sleepStage.endTime),
+                                startDate = sleepStage.startTime,
+                                endDate = sleepStage.endTime,
                                 sourceBundle = sleepSession.metadata.dataOrigin.packageName,
                                 deviceModel = fallbackDeviceModel,
                             )
@@ -346,8 +346,8 @@ internal class HealthConnectRecordProcessor(
                             QuantitySample(
                                 value = SleepStage.Deep.id.toDouble(),
                                 unit = "stage",
-                                startDate = Date.from(sleepStage.startTime),
-                                endDate = Date.from(sleepStage.endTime),
+                                startDate = sleepStage.startTime,
+                                endDate = sleepStage.endTime,
                                 sourceBundle = sleepSession.metadata.dataOrigin.packageName,
                                 deviceModel = fallbackDeviceModel,
                             )
@@ -357,8 +357,8 @@ internal class HealthConnectRecordProcessor(
                             QuantitySample(
                                 value = SleepStage.Light.id.toDouble(),
                                 unit = "stage",
-                                startDate = Date.from(sleepStage.startTime),
-                                endDate = Date.from(sleepStage.endTime),
+                                startDate = sleepStage.startTime,
+                                endDate = sleepStage.endTime,
                                 sourceBundle = sleepSession.metadata.dataOrigin.packageName,
                                 deviceModel = fallbackDeviceModel,
                             )
@@ -368,8 +368,8 @@ internal class HealthConnectRecordProcessor(
                             QuantitySample(
                                 value = SleepStage.Rem.id.toDouble(),
                                 unit = "stage",
-                                startDate = Date.from(sleepStage.startTime),
-                                endDate = Date.from(sleepStage.endTime),
+                                startDate = sleepStage.startTime,
+                                endDate = sleepStage.endTime,
                                 sourceBundle = sleepSession.metadata.dataOrigin.packageName,
                                 deviceModel = fallbackDeviceModel,
                             )
@@ -379,8 +379,8 @@ internal class HealthConnectRecordProcessor(
                             QuantitySample(
                                 value = SleepStage.Unknown.id.toDouble(),
                                 unit = "stage",
-                                startDate = Date.from(sleepStage.startTime),
-                                endDate = Date.from(sleepStage.endTime),
+                                startDate = sleepStage.startTime,
+                                endDate = sleepStage.endTime,
                                 sourceBundle = sleepSession.metadata.dataOrigin.packageName,
                                 deviceModel = fallbackDeviceModel,
                             )
@@ -390,8 +390,8 @@ internal class HealthConnectRecordProcessor(
                             QuantitySample(
                                 value = SleepStage.OutOfBed.id.toDouble(),
                                 unit = "stage",
-                                startDate = Date.from(sleepStage.startTime),
-                                endDate = Date.from(sleepStage.endTime),
+                                startDate = sleepStage.startTime,
+                                endDate = sleepStage.endTime,
                                 sourceBundle = sleepSession.metadata.dataOrigin.packageName,
                                 deviceModel = fallbackDeviceModel,
                             )
@@ -418,8 +418,8 @@ internal class HealthConnectRecordProcessor(
             HCQuantitySample(
                 value = it.energy.inKilocalories,
                 unit = SampleType.ActiveCaloriesBurned.unit,
-                startDate = it.startTime.toDate(),
-                endDate = it.endTime.toDate(),
+                startDate = it.startTime,
+                endDate = it.endTime,
                 metadata = it.metadata,
             ).toQuantitySample(currentDevice)
         }
@@ -427,8 +427,8 @@ internal class HealthConnectRecordProcessor(
             HCQuantitySample(
                 value = it.basalMetabolicRate.inKilocaloriesPerDay,
                 unit = SampleType.BasalMetabolicRate.unit,
-                startDate = it.time.toDate(),
-                endDate = it.time.toDate(),
+                startDate = it.time,
+                endDate = it.time,
                 metadata = it.metadata,
             ).toQuantitySample(currentDevice)
         }
@@ -436,8 +436,8 @@ internal class HealthConnectRecordProcessor(
             HCQuantitySample(
                 value = it.distance.inMeters,
                 unit = SampleType.Distance.unit,
-                startDate = it.startTime.toDate(),
-                endDate = it.endTime.toDate(),
+                startDate = it.startTime,
+                endDate = it.endTime,
                 metadata = it.metadata,
             ).toQuantitySample(currentDevice)
         }
@@ -445,8 +445,8 @@ internal class HealthConnectRecordProcessor(
             HCQuantitySample(
                 value = it.floors,
                 unit = SampleType.FloorsClimbed.unit,
-                startDate = it.startTime.toDate(),
-                endDate = it.endTime.toDate(),
+                startDate = it.startTime,
+                endDate = it.endTime,
                 metadata = it.metadata,
             ).toQuantitySample(currentDevice)
         }
@@ -454,8 +454,8 @@ internal class HealthConnectRecordProcessor(
             HCQuantitySample(
                 value = it.count.toDouble(),
                 unit = SampleType.Steps.unit,
-                startDate = it.startTime.toDate(),
-                endDate = it.endTime.toDate(),
+                startDate = it.startTime,
+                endDate = it.endTime,
                 metadata = it.metadata,
             ).toQuantitySample(currentDevice)
 
@@ -464,8 +464,8 @@ internal class HealthConnectRecordProcessor(
             HCQuantitySample(
                 value = it.vo2MillilitersPerMinuteKilogram,
                 unit = SampleType.Vo2Max.unit,
-                startDate = it.time.toDate(),
-                endDate = it.time.toDate(),
+                startDate = it.time,
+                endDate = it.time,
                 metadata = it.metadata,
             ).toQuantitySample(currentDevice)
         }
@@ -548,8 +548,8 @@ internal class HealthConnectRecordProcessor(
             HCQuantitySample(
                 value = it.percentage.value,
                 unit = SampleType.OxygenSaturation.unit,
-                startDate = Date.from(it.time),
-                endDate = Date.from(it.time),
+                startDate = it.time,
+                endDate = it.time,
                 metadata = it.metadata,
             ).toQuantitySample(fallbackDeviceModel)
         }
@@ -563,8 +563,8 @@ internal class HealthConnectRecordProcessor(
             HCQuantitySample(
                 value = it.heartRateVariabilityMillis,
                 unit = SampleType.HeartRateVariabilityRmssd.unit,
-                startDate = it.time.toDate(),
-                endDate = it.time.toDate(),
+                startDate = it.time,
+                endDate = it.time,
                 metadata = it.metadata,
             ).toQuantitySample(fallbackDeviceModel)
         }
@@ -578,8 +578,8 @@ internal class HealthConnectRecordProcessor(
             HCQuantitySample(
                 value = it.rate,
                 unit = SampleType.RespiratoryRate.unit,
-                startDate = it.time.toDate(),
-                endDate = it.time.toDate(),
+                startDate = it.time,
+                endDate = it.time,
                 metadata = it.metadata,
             ).toQuantitySample(fallbackDeviceModel)
 
@@ -599,8 +599,8 @@ internal class HealthConnectRecordProcessor(
                     HCQuantitySample(
                         value = averagedSample.toDouble(),
                         unit = SampleType.HeartRate.unit,
-                        startDate = it.first().time.toDate(),
-                        endDate = it.last().time.toDate(),
+                        startDate = it.first().time,
+                        endDate = it.last().time,
                         metadata = heartRateRecord.metadata,
                     ).toQuantitySample(fallbackDeviceModel)
                 }
@@ -615,8 +615,8 @@ internal class HealthConnectRecordProcessor(
             HCQuantitySample(
                 value = it.beatsPerMinute.toDouble(),
                 unit = SampleType.HeartRate.unit,
-                startDate = it.time.toDate(),
-                endDate = it.time.toDate(),
+                startDate = it.time,
+                endDate = it.time,
                 metadata = it.metadata,
             ).toQuantitySample(fallbackDeviceModel)
         }

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordUploader.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordUploader.kt
@@ -13,6 +13,7 @@ import io.tryvital.client.services.data.SleepPayload
 import io.tryvital.client.services.data.SummaryPayload
 import io.tryvital.client.services.data.TimeseriesPayload
 import io.tryvital.client.services.data.WorkoutPayload
+import java.time.Instant
 import java.util.Date
 
 
@@ -20,8 +21,8 @@ interface RecordUploader {
 
     suspend fun uploadSleeps(
         userId: String,
-        startDate: Date?,
-        endDate: Date?,
+        startDate: Instant?,
+        endDate: Instant?,
         timeZoneId: String?,
         sleepPayloads: List<SleepPayload>,
         stage: DataStage = DataStage.Daily,
@@ -29,8 +30,8 @@ interface RecordUploader {
 
     suspend fun uploadBody(
         userId: String,
-        startDate: Date?,
-        endDate: Date?,
+        startDate: Instant?,
+        endDate: Instant?,
         timeZoneId: String?,
         bodyPayload: BodyPayload,
         stage: DataStage = DataStage.Daily,
@@ -38,8 +39,8 @@ interface RecordUploader {
 
     suspend fun uploadProfile(
         userId: String,
-        startDate: Date?,
-        endDate: Date?,
+        startDate: Instant?,
+        endDate: Instant?,
         timeZoneId: String?,
         profilePayload: ProfilePayload,
         stage: DataStage = DataStage.Daily,
@@ -47,8 +48,8 @@ interface RecordUploader {
 
     suspend fun uploadActivities(
         userId: String,
-        startDate: Date?,
-        endDate: Date?,
+        startDate: Instant?,
+        endDate: Instant?,
         timeZoneId: String?,
         activityPayloads: List<ActivityPayload>,
         stage: DataStage = DataStage.Daily,
@@ -56,8 +57,8 @@ interface RecordUploader {
 
     suspend fun uploadWorkouts(
         userId: String,
-        startDate: Date?,
-        endDate: Date?,
+        startDate: Instant?,
+        endDate: Instant?,
         timeZoneId: String?,
         workoutPayloads: List<WorkoutPayload>,
         stage: DataStage = DataStage.Daily,
@@ -65,8 +66,8 @@ interface RecordUploader {
 
     suspend fun uploadBloodPressure(
         userId: String,
-        startDate: Date?,
-        endDate: Date?,
+        startDate: Instant?,
+        endDate: Instant?,
         timeZoneId: String?,
         bloodPressurePayloads: List<BloodPressureSamplePayload>,
         stage: DataStage = DataStage.Daily,
@@ -75,8 +76,8 @@ interface RecordUploader {
     suspend fun uploadQuantitySamples(
         resource: IngestibleTimeseriesResource,
         userId: String,
-        startDate: Date?,
-        endDate: Date?,
+        startDate: Instant?,
+        endDate: Instant?,
         timeZoneId: String?,
         quantitySamples: List<QuantitySamplePayload>,
         stage: DataStage = DataStage.Daily,
@@ -86,8 +87,8 @@ interface RecordUploader {
 class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUploader {
     override suspend fun uploadSleeps(
         userId: String,
-        startDate: Date?,
-        endDate: Date?,
+        startDate: Instant?,
+        endDate: Instant?,
         timeZoneId: String?,
         sleepPayloads: List<SleepPayload>,
         stage: DataStage,
@@ -106,8 +107,8 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
 
     override suspend fun uploadBody(
         userId: String,
-        startDate: Date?,
-        endDate: Date?,
+        startDate: Instant?,
+        endDate: Instant?,
         timeZoneId: String?,
         bodyPayload: BodyPayload,
         stage: DataStage,
@@ -126,8 +127,8 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
 
     override suspend fun uploadProfile(
         userId: String,
-        startDate: Date?,
-        endDate: Date?,
+        startDate: Instant?,
+        endDate: Instant?,
         timeZoneId: String?,
         profilePayload: ProfilePayload,
         stage: DataStage,
@@ -146,8 +147,8 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
 
     override suspend fun uploadActivities(
         userId: String,
-        startDate: Date?,
-        endDate: Date?,
+        startDate: Instant?,
+        endDate: Instant?,
         timeZoneId: String?,
         activityPayloads: List<ActivityPayload>,
         stage: DataStage,
@@ -166,8 +167,8 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
 
     override suspend fun uploadWorkouts(
         userId: String,
-        startDate: Date?,
-        endDate: Date?,
+        startDate: Instant?,
+        endDate: Instant?,
         timeZoneId: String?,
         workoutPayloads: List<WorkoutPayload>,
         stage: DataStage,
@@ -187,8 +188,8 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
     override suspend fun uploadQuantitySamples(
         resource: IngestibleTimeseriesResource,
         userId: String,
-        startDate: Date?,
-        endDate: Date?,
+        startDate: Instant?,
+        endDate: Instant?,
         timeZoneId: String?,
         quantitySamples: List<QuantitySamplePayload>,
         stage: DataStage,
@@ -207,8 +208,8 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
 
     override suspend fun uploadBloodPressure(
         userId: String,
-        startDate: Date?,
-        endDate: Date?,
+        startDate: Instant?,
+        endDate: Instant?,
         timeZoneId: String?,
         bloodPressurePayloads: List<BloodPressureSamplePayload>,
         stage: DataStage,

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncWorker.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncWorker.kt
@@ -54,7 +54,6 @@ const val VITAL_SYNC_NOTIFICATION_ID = 123
 
 internal val moshi by lazy {
     Moshi.Builder()
-        .add(Date::class.java, Rfc3339DateJsonAdapter())
         .add(Instant::class.java, InstantJsonAdapter)
         .add(ResourceSyncState.adapterFactory)
         .build()
@@ -400,8 +399,8 @@ internal class ResourceSyncWorker(appContext: Context, workerParams: WorkerParam
                 mergedData,
                 uploader = recordUploader,
                 stage = stage,
-                start = stageStart?.toDate(),
-                end = stageEnd?.toDate(),
+                start = stageStart,
+                end = stageEnd,
                 timeZoneId = timeZone.id,
                 userId = userId,
             )

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/uploadResources.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/uploadResources.kt
@@ -5,6 +5,7 @@ import io.tryvital.vitalhealthconnect.model.processedresource.ProcessedResourceD
 import io.tryvital.vitalhealthconnect.model.processedresource.SummaryData
 import io.tryvital.vitalhealthconnect.model.processedresource.TimeSeriesData
 import io.tryvital.vitalhealthconnect.records.RecordUploader
+import java.time.Instant
 import java.util.Date
 
 internal suspend fun uploadResources(
@@ -12,8 +13,8 @@ internal suspend fun uploadResources(
     uploader: RecordUploader,
     stage: DataStage,
     userId: String,
-    start: Date? = null,
-    end: Date? = null,
+    start: Instant? = null,
+    end: Instant? = null,
     timeZoneId: String
 ) {
     when (data) {


### PR DESCRIPTION
Migrate from `java.utils.Date` (Java 7) to `java.time.Instant` (Java 8+)