### PR TITLE
VIT-6645: Device SDK auto-posting samples

### DIFF
--- a/VitalClient/src/main/java/io/tryvital/client/services/TimeSeriesService.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/TimeSeriesService.kt
@@ -44,29 +44,6 @@ class TimeSeriesService private constructor(private val timeSeries: TimeSeries) 
         )
     }
 
-    suspend fun sendBloodPressure(
-        userId: String,
-        timeseriesPayload: TimeseriesPayload<List<BloodPressureSamplePayload>>
-    ) {
-        timeSeries.bloodPressureTimeseriesPost(
-            userId = userId,
-            resource = "blood_pressure",
-            payload = timeseriesPayload
-        )
-    }
-
-    suspend fun sendQuantitySamples(
-        resource: IngestibleTimeseriesResource,
-        userId: String,
-        timeseriesPayload: TimeseriesPayload<List<QuantitySamplePayload>>
-    ) {
-        timeSeries.timeseriesPost(
-            userId = userId,
-            resource = resource.toString(),
-            payload = timeseriesPayload
-        )
-    }
-
     companion object {
         fun create(retrofit: Retrofit): TimeSeriesService {
             return TimeSeriesService(retrofit.create(TimeSeries::class.java))
@@ -93,19 +70,5 @@ private interface TimeSeries {
         @Query("provider") provider: String? = null,
         @Query("next_cursor") nextCursor: String? = null,
     ): GroupedSamplesResponse<BloodPressureSample>
-
-    @POST("timeseries/{user_id}/{resource}")
-    suspend fun timeseriesPost(
-        @Path("user_id") userId: String,
-        @Path("resource", encoded = true) resource: String,
-        @Body payload: TimeseriesPayload<List<QuantitySamplePayload>>
-    ): Response<Unit>
-
-    @POST("timeseries/{user_id}/{resource}")
-    suspend fun bloodPressureTimeseriesPost(
-        @Path("user_id") userId: String,
-        @Path("resource", encoded = true) resource: String,
-        @Body payload: TimeseriesPayload<List<BloodPressureSamplePayload>>
-    ): Response<Unit>
 }
 

--- a/VitalClient/src/main/java/io/tryvital/client/services/VitalPrivateService.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/VitalPrivateService.kt
@@ -5,11 +5,14 @@ import ManualProviderResponse
 import UserSDKSyncStateBody
 import UserSDKSyncStateResponse
 import io.tryvital.client.services.data.ActivityPayload
+import io.tryvital.client.services.data.BloodPressureSamplePayload
 import io.tryvital.client.services.data.BodyPayload
 import io.tryvital.client.services.data.ManualProviderSlug
 import io.tryvital.client.services.data.ProfilePayload
+import io.tryvital.client.services.data.QuantitySamplePayload
 import io.tryvital.client.services.data.SleepPayload
 import io.tryvital.client.services.data.SummaryPayload
+import io.tryvital.client.services.data.TimeseriesPayload
 import io.tryvital.client.services.data.WorkoutPayload
 import retrofit2.Response
 import retrofit2.Retrofit
@@ -63,6 +66,19 @@ interface VitalPrivateService {
     suspend fun addSleeps(
         @Path("user_id") userId: String,
         @Body body: SummaryPayload<List<SleepPayload>>
+    ): Response<Unit>
+
+    @POST("timeseries/{user_id}/{resource}")
+    suspend fun timeseriesPost(
+        @Path("user_id") userId: String,
+        @Path("resource", encoded = true) resource: String,
+        @Body payload: TimeseriesPayload<List<QuantitySamplePayload>>
+    ): Response<Unit>
+
+    @POST("timeseries/{user_id}/blood_pressure")
+    suspend fun bloodPressureTimeseriesPost(
+        @Path("user_id") userId: String,
+        @Body payload: TimeseriesPayload<List<BloodPressureSamplePayload>>
     ): Response<Unit>
 
     companion object {

--- a/VitalClient/src/main/java/io/tryvital/client/userConnectedSources.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/userConnectedSources.kt
@@ -14,6 +14,7 @@ fun VitalClient.hasUserConnectedTo(provider: ProviderSlug): Boolean {
     )
 }
 
+@VitalPrivateApi
 suspend fun VitalClient.createConnectedSourceIfNotExist(provider: ManualProviderSlug) {
     val userId = VitalClient.checkUserId()
     val slug = provider.toProviderSlug()
@@ -35,7 +36,6 @@ suspend fun VitalClient.createConnectedSourceIfNotExist(provider: ManualProvider
             .apply()
     }
 
-    @OptIn(VitalPrivateApi::class)
     try {
         // Remote Miss: Try to create the manual connected source.
         vitalPrivateService.manualProvider(

--- a/VitalDevices/src/main/java/io/tryvital/vitaldevices/Brand.kt
+++ b/VitalDevices/src/main/java/io/tryvital/vitaldevices/Brand.kt
@@ -1,9 +1,19 @@
 package io.tryvital.vitaldevices
 
+import io.tryvital.client.services.data.ManualProviderSlug
+
 sealed class Brand(val name: String) {
     object Omron : Brand("Omron")
     object AccuChek : Brand("Accu-Chek")
     object Contour : Brand("Contour")
     object Beurer : Brand("Beurer")
     object Libre : Brand("FreeStyle Libre")
+
+    fun toManualProviderSlug(): ManualProviderSlug = when (this) {
+        is Omron -> ManualProviderSlug.OmronBLE
+        is AccuChek -> ManualProviderSlug.AccuchekBLE
+        is Contour -> ManualProviderSlug.ContourBLE
+        is Beurer -> ManualProviderSlug.BeurerBLE
+        is Libre -> ManualProviderSlug.LibreBLE
+    }
 }

--- a/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/BloodPressureSample.kt
+++ b/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/BloodPressureSample.kt
@@ -1,9 +1,0 @@
-package io.tryvital.vitaldevices.devices
-
-import io.tryvital.client.services.data.QuantitySamplePayload
-
-data class BloodPressureSample(
-    val systolic: QuantitySamplePayload,
-    val diastolic: QuantitySamplePayload,
-    val pulse: QuantitySamplePayload?,
-)

--- a/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/GlucoseMeter1808.kt
+++ b/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/GlucoseMeter1808.kt
@@ -33,6 +33,10 @@ class GlucoseMeter1808(
     scannedBluetoothDevice = scannedBluetoothDevice,
     scannedDevice = scannedDevice
 ), GlucoseMeter {
+    override fun onReceivedAll(samples: List<QuantitySamplePayload>) {
+        postGlucoseSamples(context, scannedDevice.deviceModel.brand.toManualProviderSlug(), samples)
+    }
+
     override fun mapRawData(
         device: BluetoothDevice, data: Data
     ): QuantitySamplePayload? {

--- a/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/Libre1Reader.kt
+++ b/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/Libre1Reader.kt
@@ -2,6 +2,7 @@ package io.tryvital.vitaldevices.devices
 
 import android.app.Activity
 import android.content.pm.PackageManager.PERMISSION_GRANTED
+import io.tryvital.client.services.data.ManualProviderSlug
 import io.tryvital.client.services.data.QuantitySamplePayload
 import io.tryvital.vitaldevices.PermissionMissing
 import io.tryvital.vitaldevices.devices.nfc.Glucose
@@ -81,6 +82,8 @@ internal class Libre1ReaderImpl(private val activity: Activity): Libre1Reader {
             continuation.invokeOnCancellation { nfc?.close() }
         }
 
+        val samples = glucose.map { quantitySampleFromGlucose(it) }
+        postGlucoseSamples(activity.applicationContext, ManualProviderSlug.LibreBLE, samples)
 
         return Libre1Read(
             samples = glucose.map { quantitySampleFromGlucose(it) },

--- a/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/postSamples.kt
+++ b/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/postSamples.kt
@@ -18,6 +18,10 @@ import kotlinx.coroutines.launch
 import java.util.TimeZone
 
 internal fun postGlucoseSamples(context: Context, provider: ManualProviderSlug, samples: List<QuantitySamplePayload>) {
+    if (samples.isEmpty()) {
+        return
+    }
+
     GlobalScope.launch {
         try {
             postGlucoseSamplesImpl(context, provider, samples)
@@ -30,6 +34,10 @@ internal fun postGlucoseSamples(context: Context, provider: ManualProviderSlug, 
 }
 
 internal fun postBloodPressureSamples(context: Context, provider: ManualProviderSlug, samples: List<BloodPressureSamplePayload>) {
+    if (samples.isEmpty()) {
+        return
+    }
+
     GlobalScope.launch {
         try {
             postBloodPressureSamplesImpl(context, provider, samples)

--- a/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/postSamples.kt
+++ b/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/postSamples.kt
@@ -1,0 +1,83 @@
+@file:OptIn(VitalPrivateApi::class, DelicateCoroutinesApi::class)
+
+package io.tryvital.vitaldevices.devices
+
+import android.content.Context
+import io.tryvital.client.VitalClient
+import io.tryvital.client.createConnectedSourceIfNotExist
+import io.tryvital.client.services.VitalPrivateApi
+import io.tryvital.client.services.data.BloodPressureSamplePayload
+import io.tryvital.client.services.data.DataStage
+import io.tryvital.client.services.data.ManualProviderSlug
+import io.tryvital.client.services.data.QuantitySamplePayload
+import io.tryvital.client.services.data.TimeseriesPayload
+import io.tryvital.client.utils.VitalLogger
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import java.util.TimeZone
+
+internal fun postGlucoseSamples(context: Context, provider: ManualProviderSlug, samples: List<QuantitySamplePayload>) {
+    GlobalScope.launch {
+        try {
+            postGlucoseSamplesImpl(context, provider, samples)
+            VitalLogger.getOrCreate().logI("[Device] posted ${samples.count()} glucose for $provider")
+
+        } catch (e: Throwable) {
+            VitalLogger.getOrCreate().logE("[Device] failed to post ${samples.count()} glucose for $provider", e)
+        }
+    }
+}
+
+internal fun postBloodPressureSamples(context: Context, provider: ManualProviderSlug, samples: List<BloodPressureSamplePayload>) {
+    GlobalScope.launch {
+        try {
+            postBloodPressureSamplesImpl(context, provider, samples)
+            VitalLogger.getOrCreate().logI("[Device] posted ${samples.count()} BP for $provider")
+
+        } catch (e: Throwable) {
+            VitalLogger.getOrCreate().logE("[Device] failed to post ${samples.count()} BP for $provider", e)
+        }
+    }
+}
+
+private suspend fun postGlucoseSamplesImpl(context: Context, provider: ManualProviderSlug, samples: List<QuantitySamplePayload>) {
+    val client = VitalClient.getOrCreate(context)
+    if (VitalClient.Status.SignedIn !in VitalClient.status) {
+        return
+    }
+
+    client.createConnectedSourceIfNotExist(provider)
+    client.vitalPrivateService.timeseriesPost(
+        userId = VitalClient.checkUserId(),
+        resource = "glucose",
+        payload = TimeseriesPayload(
+            stage = DataStage.Daily,
+            data = samples,
+            startDate = null,
+            endDate = null,
+            timeZoneId = TimeZone.getDefault().id,
+            provider = provider,
+        )
+    )
+}
+
+private suspend fun postBloodPressureSamplesImpl(context: Context, provider: ManualProviderSlug, samples: List<BloodPressureSamplePayload>) {
+    val client = VitalClient.getOrCreate(context)
+    if (VitalClient.Status.SignedIn !in VitalClient.status) {
+        return
+    }
+
+    client.createConnectedSourceIfNotExist(provider)
+    client.vitalPrivateService.bloodPressureTimeseriesPost(
+        userId = VitalClient.checkUserId(),
+        payload = TimeseriesPayload(
+            stage = DataStage.Daily,
+            data = samples,
+            startDate = null,
+            endDate = null,
+            timeZoneId = TimeZone.getDefault().id,
+            provider = provider,
+        )
+    )
+}

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordUploader.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordUploader.kt
@@ -197,8 +197,8 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         quantitySamples: List<QuantitySamplePayload>,
         stage: DataStage,
     ) {
-        vitalClient.vitalsService.sendQuantitySamples(
-            resource, userId, TimeseriesPayload(
+        vitalClient.vitalPrivateService.timeseriesPost(
+            userId, resource.toString(), TimeseriesPayload(
                 stage = stage,
                 provider = ManualProviderSlug.HealthConnect,
                 startDate = startDate,
@@ -217,7 +217,7 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         bloodPressurePayloads: List<BloodPressureSamplePayload>,
         stage: DataStage,
     ) {
-        vitalClient.vitalsService.sendBloodPressure(
+        vitalClient.vitalPrivateService.bloodPressureTimeseriesPost(
             userId, TimeseriesPayload(
                 stage = stage,
                 provider = ManualProviderSlug.HealthConnect,

--- a/app/src/main/java/io/tryvital/sample/ui/device/DeviceModel.kt
+++ b/app/src/main/java/io/tryvital/sample/ui/device/DeviceModel.kt
@@ -7,9 +7,9 @@ import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import io.tryvital.client.services.data.BloodPressureSamplePayload
 import io.tryvital.client.services.data.QuantitySamplePayload
 import io.tryvital.vitaldevices.*
-import io.tryvital.vitaldevices.devices.BloodPressureSample
 import io.tryvital.vitaldevices.devices.Libre1Reader
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
@@ -176,7 +176,7 @@ data class BluetoothViewModelState(
     val device: DeviceModel,
     val scannedDevices: List<ScannedDevice>,
     val samples: List<QuantitySamplePayload>,
-    val bloodPressureSamples: List<BloodPressureSample>,
+    val bloodPressureSamples: List<BloodPressureSamplePayload>,
     val canScan: Boolean,
     val isScanning: Boolean,
     val isReading: Boolean,


### PR DESCRIPTION
Move timeseries POST methods to VitalPrivateService.

Mark `createConnectedSourceIfNotExist` as VitalPrivateApi.

Devices SDK would now try to auto-post glucose and blood pressure samples after reading them, if the Core SDK has signed-in with a user.