### PR TITLE
VIT-6651: Port the 3-pong permission mapping ruleset to Health Connect

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,10 +1,7 @@
 name: Android CI
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 jobs:
   build:
@@ -13,6 +10,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
       - name: set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -22,13 +20,17 @@ jobs:
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+
       - name: Run lint
         run: ./gradlew lint
-      - uses: yutailang0119/action-android-lint@v3
+
+      - uses: yutailang0119/action-android-lint@v4
         with:
           report-path: build/reports/*.xml
+
       - name: Build with Gradle
-        run: ./gradlew :VitalClient:testDebugUnitTest
+        run: ./gradlew :VitalClient:testDebugUnitTest :VitalDevices:testDebugUnitTest :VitalHealthConnect:testDebugUnitTest
+
       - name: Android Test Report
         uses: asadmansr/android-test-report-action@v1.2.0
         if: ${{ always() }}

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalPermissionRequestContract.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalPermissionRequestContract.kt
@@ -81,7 +81,7 @@ class VitalPermissionRequestContract(
 
     private fun processGrantedPermissionsAsync(requested: Set<String>, granted: Set<String>): Deferred<PermissionOutcome> {
         val readGrants = readResources
-            .filter { granted.containsAll(manager.permissionsRequiredToSyncResources(setOf(it))) }
+            .filter { granted.containsAll(manager.readPermissionsRequiredByResources(setOf(it))) }
             .toSet()
 
         val writeGrants = writeResources
@@ -135,6 +135,6 @@ class VitalPermissionRequestContract(
 
     private fun permissionsToRequest(): Set<String> {
         return manager.permissionsRequiredToWriteResources(this.writeResources) +
-                manager.permissionsRequiredToSyncResources(this.readResources)
+                manager.readPermissionsToRequestForResources(this.readResources)
     }
 }

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/VitalResource.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/VitalResource.kt
@@ -126,7 +126,9 @@ internal data class RecordTypeRequirements(
 }
 
 @JvmInline
-value class RemappedVitalResource(val wrapped: VitalResource)
+value class RemappedVitalResource(val wrapped: VitalResource) {
+    override fun toString() = wrapped.toString()
+}
 
 /**
  * VitalResource remapping.

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/VitalResource.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/VitalResource.kt
@@ -4,21 +4,6 @@ import androidx.health.connect.client.records.*
 
 import kotlin.reflect.KClass
 
-val healthResources = setOf(
-    VitalResource.Profile,
-    VitalResource.Body,
-    VitalResource.Workout,
-    VitalResource.Activity,
-    VitalResource.Sleep,
-    VitalResource.Glucose,
-    VitalResource.BloodPressure,
-    VitalResource.HeartRate,
-    VitalResource.Steps,
-    VitalResource.ActiveEnergyBurned,
-    VitalResource.BasalEnergyBurned,
-    VitalResource.Water,
-)
-
 sealed class VitalResource(val name: String) {
     object Profile : VitalResource("profile")
     object Body : VitalResource("body")
@@ -80,6 +65,70 @@ sealed class VitalResource(val name: String) {
 }
 
 /**
+ * Describes how Health Connect sample types map to a particular VitalResource.
+ *
+ * ### `createPermissionRequestContract(_:)` behaviour:
+ * We request `required` + `optional` + `supplementary`.
+ *
+ * ### `hasAskedForPermission(_:)` behaviour:
+ * If `required` is non-empty:
+ *   - A VitalResource is "asked" if and only if all `required` sample types have been asked.
+ * If `required` is empty:
+ *   - A VitalResource is "asked" if at least one `optional` sample types have been asked.
+ * In both cases, `supplementary` is not considered at all.
+ *
+ * Some sample types may appear in multiple `VitalResource`s:
+ * 1. Each sample type can only be associated with ** one** VitalResource as their `required` or `optional` types.
+ * 2. A sample type can optionally be marked as a `supplementary` type of any other VitalResource.
+ *
+ * Example:
+ * - `VitalResource.heartrate` is the primary resource for `HeartRateRecord::class`.
+ * - Activity, workouts and sleeps all need _supplementary_ heartrate permission for statistics, but can function without it.
+ *   So they list `HeartRateRecord::class` as their `supplementary` types.
+ */
+internal data class RecordTypeRequirements(
+    /**
+     * The required set of Record types of a `VitalResource`.
+     *
+     * This must not change once the `VitalResource` is introduced, especially if
+     * the `VitalResource` is a fully computed resource like `activity`.
+     */
+    val required: List<KClass<out Record>>,
+
+    /**
+     * An optional set of Record types of a `VitalResource`.
+     * New types can be added or removed from this list.
+     */
+    val optional: List<KClass<out Record>>,
+
+    /**
+     * An "supplementary" set of Record types of a `VitalResource`.
+     * New types can be added or removed from this list.
+     */
+    val supplementary: List<KClass<out Record>>,
+) {
+
+    fun isResourceActive(query: (KClass<out Record>) -> Boolean): Boolean {
+        return if (required.isEmpty()) {
+            optional.any(query)
+        } else {
+            required.all(query)
+        }
+    }
+
+    val allRecordTypes: Set<KClass<out Record>> get()
+        = required.toSet().union(optional).union(supplementary)
+
+    companion object {
+        fun single(recordType: KClass<out Record>): RecordTypeRequirements
+            = RecordTypeRequirements(required = listOf(recordType), optional = emptyList(), supplementary = emptyList())
+    }
+}
+
+@JvmInline
+value class RemappedVitalResource(val wrapped: VitalResource)
+
+/**
  * VitalResource remapping.
  *
  * All individual activity timeseries resources are remapped to Activity for processing.
@@ -87,11 +136,11 @@ sealed class VitalResource(val name: String) {
  * compute Activity Day Summary & pull individual samples adaptively in accordance to the permission
  * state.
  */
-fun VitalResource.remapped(): VitalResource = when (this) {
+internal fun VitalResource.remapped(): RemappedVitalResource = when (this) {
     VitalResource.ActiveEnergyBurned, VitalResource.BasalEnergyBurned, VitalResource.Steps ->
-        VitalResource.Activity
+        RemappedVitalResource(VitalResource.Activity)
 
-    else -> this
+    else -> RemappedVitalResource(this)
 }
 
 /**
@@ -99,38 +148,55 @@ fun VitalResource.remapped(): VitalResource = when (this) {
  *
  * This covers all the record types which a VitalResource will **READ**.
  */
-fun VitalResource.recordTypeDependencies(): List<KClass<out Record>> = when (this) {
-    VitalResource.Water -> listOf(HydrationRecord::class)
-    VitalResource.ActiveEnergyBurned -> listOf(ActiveCaloriesBurnedRecord::class)
-    VitalResource.Activity -> listOf(
-        ActiveCaloriesBurnedRecord::class,
-        BasalMetabolicRateRecord::class,
-        StepsRecord::class,
-        DistanceRecord::class,
-        FloorsClimbedRecord::class,
+internal fun VitalResource.recordTypeDependencies(): RecordTypeRequirements = when (this) {
+    VitalResource.ActiveEnergyBurned -> RecordTypeRequirements.single(ActiveCaloriesBurnedRecord::class)
+    VitalResource.BasalEnergyBurned -> RecordTypeRequirements.single(BasalMetabolicRateRecord::class)
+    VitalResource.Steps -> RecordTypeRequirements.single(StepsRecord::class)
+
+    VitalResource.BloodPressure -> RecordTypeRequirements.single(BloodPressureRecord::class)
+    VitalResource.Glucose -> RecordTypeRequirements.single(BloodGlucoseRecord::class)
+    VitalResource.HeartRate -> RecordTypeRequirements.single(HeartRateRecord::class)
+    VitalResource.HeartRateVariability -> RecordTypeRequirements.single(HeartRateVariabilityRmssdRecord::class)
+
+    VitalResource.Water -> RecordTypeRequirements.single(HydrationRecord::class)
+    VitalResource.Profile -> RecordTypeRequirements.single(HeightRecord::class)
+
+    VitalResource.Activity -> RecordTypeRequirements(
+        required = emptyList(),
+        optional = listOf(
+            ActiveCaloriesBurnedRecord::class,
+            BasalMetabolicRateRecord::class,
+            StepsRecord::class,
+            DistanceRecord::class,
+            FloorsClimbedRecord::class,
+        ),
+        supplementary = emptyList(),
     )
-    VitalResource.BasalEnergyBurned -> listOf(BasalMetabolicRateRecord::class)
-    VitalResource.BloodPressure -> listOf(BloodPressureRecord::class)
-    VitalResource.Body -> listOf(
-        BodyFatRecord::class,
-        WeightRecord::class,
+    VitalResource.Body -> RecordTypeRequirements(
+        required = emptyList(),
+        optional = listOf(
+            BodyFatRecord::class,
+            WeightRecord::class,
+        ),
+        supplementary = emptyList()
     )
-    VitalResource.Glucose -> listOf(BloodGlucoseRecord::class)
-    VitalResource.HeartRate -> listOf(HeartRateRecord::class)
-    VitalResource.HeartRateVariability -> listOf(HeartRateVariabilityRmssdRecord::class)
-    VitalResource.Profile -> listOf(HeightRecord::class)
-    VitalResource.Sleep -> listOf(
-        SleepSessionRecord::class,
-        HeartRateRecord::class,
-        HeartRateVariabilityRmssdRecord::class,
-        RespiratoryRateRecord::class,
-        RestingHeartRateRecord::class,
-        OxygenSaturationRecord::class,
+    VitalResource.Sleep -> RecordTypeRequirements(
+        required = listOf(SleepSessionRecord::class),
+        optional = emptyList(),
+        supplementary = listOf(
+            HeartRateRecord::class,
+            HeartRateVariabilityRmssdRecord::class,
+            RespiratoryRateRecord::class,
+            RestingHeartRateRecord::class,
+            OxygenSaturationRecord::class,
+        )
     )
-    VitalResource.Steps -> listOf(StepsRecord::class)
-    VitalResource.Workout -> listOf(
-        ExerciseSessionRecord::class,
-        HeartRateRecord::class,
+    VitalResource.Workout -> RecordTypeRequirements(
+        required = listOf(ExerciseSessionRecord::class),
+        optional = emptyList(),
+        supplementary = listOf(
+            HeartRateRecord::class,
+        ),
     )
 }
 
@@ -145,7 +211,7 @@ fun VitalResource.recordTypeDependencies(): List<KClass<out Record>> = when (thi
  * payload, on the assumption that these data should have been readily available in the Health
  * Connect data store.
  */
-fun VitalResource.recordTypeChangesToTriggerSync(): List<KClass<out Record>> = when (this) {
+internal fun VitalResource.recordTypeChangesToTriggerSync(): List<KClass<out Record>> = when (this) {
     VitalResource.Water -> listOf(HydrationRecord::class)
     VitalResource.Activity -> listOf(
         ActiveCaloriesBurnedRecord::class,

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/LocalSyncState.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/LocalSyncState.kt
@@ -1,6 +1,7 @@
 package io.tryvital.vitalhealthconnect.workers
 
 import com.squareup.moshi.JsonClass
+import io.tryvital.vitalhealthconnect.model.RemappedVitalResource
 import io.tryvital.vitalhealthconnect.model.VitalResource
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -14,7 +15,7 @@ data class LocalSyncState(
     val expiresAt: Instant,
 ) {
 
-    fun historicalStartDate(@Suppress("UNUSED_PARAMETER") resource: VitalResource): Instant {
+    fun historicalStartDate(@Suppress("UNUSED_PARAMETER") resource: RemappedVitalResource): Instant {
         return historicalStageAnchor.minus(defaultDaysToBackfill, ChronoUnit.DAYS)
     }
 }

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncStarter.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncStarter.kt
@@ -48,7 +48,7 @@ internal data class ResourceSyncStarterInput(
     val startForeground: Boolean,
 ) {
     fun toData(): Data = Data.Builder().run {
-        putStringArray("resources", resources.map { it.toString() }.toTypedArray())
+        putStringArray("resources", resources.map { it.wrapped.toString() }.toTypedArray())
         putBoolean("startForeground", startForeground)
         build()
     }

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncStarter.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/ResourceSyncStarter.kt
@@ -21,6 +21,7 @@ import io.tryvital.vitalhealthconnect.UnSecurePrefKeys
 import io.tryvital.vitalhealthconnect.VitalHealthConnectManager
 import io.tryvital.vitalhealthconnect.isConnectedToInternet
 import io.tryvital.vitalhealthconnect.markAutoSyncSuccess
+import io.tryvital.vitalhealthconnect.model.RemappedVitalResource
 import io.tryvital.vitalhealthconnect.model.VitalResource
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -34,7 +35,7 @@ import java.util.UUID
 import kotlin.random.Random
 
 internal data class ResourceSyncStarterInput(
-    val resources: Set<VitalResource>,
+    val resources: Set<RemappedVitalResource>,
     /**
      * Whether the work should request WorkManager to start a foregorund service.
      * For sync triggered by user interaction, or sync triggered by ProcessLifecycle ON_START,
@@ -54,7 +55,9 @@ internal data class ResourceSyncStarterInput(
 
     companion object {
         fun fromData(data: Data) = ResourceSyncStarterInput(
-            resources = data.getStringArray("resources")?.mapTo(mutableSetOf()) { VitalResource.valueOf(it) } ?: emptySet(),
+            resources = data.getStringArray("resources")?.mapTo(mutableSetOf()) {
+                RemappedVitalResource(VitalResource.valueOf(it))
+            } ?: emptySet(),
             startForeground = data.getBoolean("startForeground", true),
         )
     }
@@ -110,7 +113,10 @@ internal class ResourceSyncStarter(appContext: Context, workerParams: WorkerPara
                 return Result.failure()
             }
 
-            val notification = syncNotificationBuilder.build(applicationContext, input.resources)
+            val notification = syncNotificationBuilder.build(
+                applicationContext,
+                input.resources.mapTo(mutableSetOf()) { it.wrapped }
+            )
 
             setForeground(
                 ForegroundInfo(VITAL_SYNC_NOTIFICATION_ID, notification, foregroundServiceType())
@@ -137,7 +143,7 @@ internal class ResourceSyncStarter(appContext: Context, workerParams: WorkerPara
         for (resource in input.resources) {
             val workRequest = OneTimeWorkRequestBuilder<ResourceSyncWorker>()
                 .setInputData(ResourceSyncWorkerInput(resource = resource).toData())
-                .addTag(resource.name)
+                .addTag(resource.wrapped.name)
                 .build()
 
             val workManager = WorkManager.getInstance(applicationContext)

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/processChangesResponse.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/processChangesResponse.kt
@@ -19,6 +19,7 @@ import androidx.health.connect.client.records.StepsRecord
 import androidx.health.connect.client.records.Vo2MaxRecord
 import androidx.health.connect.client.records.WeightRecord
 import androidx.health.connect.client.response.ChangesResponse
+import io.tryvital.vitalhealthconnect.model.RemappedVitalResource
 import io.tryvital.vitalhealthconnect.model.VitalResource
 import io.tryvital.vitalhealthconnect.model.processedresource.ProcessedResourceData
 import io.tryvital.vitalhealthconnect.model.processedresource.TimeSeriesData
@@ -31,7 +32,7 @@ import java.util.*
 import kotlin.reflect.KClass
 
 internal suspend fun processChangesResponse(
-    resource: VitalResource,
+    resource: RemappedVitalResource,
     responses: ChangesResponse,
     timeZone: TimeZone,
     currentDevice: String,
@@ -53,7 +54,7 @@ internal suspend fun processChangesResponse(
     ): ProcessedResourceData = process(currentDevice, records)
         .let(ProcessedResourceData::TimeSeries)
 
-    return when (resource.remapped()) {
+    return when (resource.wrapped) {
         VitalResource.ActiveEnergyBurned, VitalResource.BasalEnergyBurned, VitalResource.Steps ->
             throw IllegalArgumentException("Unexpected resource post remapped(): $resource")
 

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/readResource.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/workers/readResource.kt
@@ -1,5 +1,6 @@
 package io.tryvital.vitalhealthconnect.workers
 
+import io.tryvital.vitalhealthconnect.model.RemappedVitalResource
 import io.tryvital.vitalhealthconnect.model.VitalResource
 import io.tryvital.vitalhealthconnect.model.processedresource.ProcessedResourceData
 import io.tryvital.vitalhealthconnect.model.processedresource.TimeSeriesData
@@ -11,7 +12,7 @@ import java.time.Instant
 import java.util.TimeZone
 
 internal suspend fun readResourceByTimeRange(
-    resource: VitalResource,
+    resource: RemappedVitalResource,
     startTime: Instant,
     endTime: Instant,
     timeZone: TimeZone,
@@ -28,7 +29,7 @@ internal suspend fun readResourceByTimeRange(
         read(startTime, endTime)
     ).let(ProcessedResourceData::TimeSeries)
 
-    return when (resource.remapped()) {
+    return when (resource.wrapped) {
         VitalResource.ActiveEnergyBurned, VitalResource.BasalEnergyBurned, VitalResource.Steps ->
             throw IllegalArgumentException("Unexpected resource post remapped(): $resource")
 

--- a/VitalHealthConnect/src/test/kotlin/io/tryvital/vitalhealthconnect/ResourceSyncStateTests.kt
+++ b/VitalHealthConnect/src/test/kotlin/io/tryvital/vitalhealthconnect/ResourceSyncStateTests.kt
@@ -14,15 +14,15 @@ import java.time.Instant
 @OptIn(ExperimentalCoroutinesApi::class)
 class ResourceSyncStateTests {
     private val historicalStub = ResourceSyncState.Historical(
-        start = Instant.parse("2023-01-23T12:34:56Z").toDate(),
-        end = Instant.parse("2023-01-25T23:54:32Z").toDate(),
+        start = Instant.parse("2023-01-23T12:34:56Z"),
+        end = Instant.parse("2023-01-25T23:54:32Z"),
     )
-    private val historicalJsonStub = """{"type":"historical","start":"2023-01-23T12:34:56.000Z","end":"2023-01-25T23:54:32.000Z"}"""
+    private val historicalJsonStub = """{"type":"historical","start":"2023-01-23T12:34:56Z","end":"2023-01-25T23:54:32Z"}"""
     private val incrementalStub = ResourceSyncState.Incremental(
         changesToken = "this-is-not-a-token",
-        lastSync = Instant.parse("2023-01-25T23:54:32Z").toDate()
+        lastSync = Instant.parse("2023-01-25T23:54:32Z")
     )
-    private val incrementalJsonStub = """{"type":"incremental","changesToken":"this-is-not-a-token","lastSync":"2023-01-25T23:54:32.000Z"}"""
+    private val incrementalJsonStub = """{"type":"incremental","changesToken":"this-is-not-a-token","lastSync":"2023-01-25T23:54:32Z"}"""
     private val adapter: JsonAdapter<ResourceSyncState> = moshi.adapter(ResourceSyncState::class.java)
 
     @Test

--- a/VitalHealthConnect/src/test/kotlin/io/tryvital/vitalhealthconnect/VitalResourceTests.kt
+++ b/VitalHealthConnect/src/test/kotlin/io/tryvital/vitalhealthconnect/VitalResourceTests.kt
@@ -1,0 +1,136 @@
+package io.tryvital.vitalhealthconnect
+
+import androidx.health.connect.client.records.ActiveCaloriesBurnedRecord
+import androidx.health.connect.client.records.Record
+import androidx.health.connect.client.records.SpeedRecord
+import androidx.health.connect.client.records.StepsRecord
+import io.tryvital.vitalhealthconnect.model.RecordTypeRequirements
+import io.tryvital.vitalhealthconnect.model.VitalResource
+import io.tryvital.vitalhealthconnect.model.recordTypeDependencies
+import io.tryvital.vitalhealthconnect.model.remapped
+import org.junit.Assert
+import org.junit.Test
+import kotlin.reflect.KClass
+
+class VitalResourceTests {
+    @Test
+    fun `RecordTypeRequirements singleObjectType`() {
+        val requirements = RecordTypeRequirements (
+            required = listOf(StepsRecord::class),
+            optional = emptyList(),
+            supplementary = emptyList(),
+        )
+
+        // required[0] has been asked
+        Assert.assertTrue(requirements.isResourceActive { true })
+
+        // required[0] has not been asked
+        Assert.assertFalse(requirements.isResourceActive { false })
+    }
+
+    @Test
+    fun `RecordTypeRequirements multipleRequiredObjectTypes`() {
+        val requirements = RecordTypeRequirements (
+            required = listOf(
+                StepsRecord::class,
+                ActiveCaloriesBurnedRecord::class,
+                SpeedRecord::class,
+            ),
+            optional = emptyList(),
+            supplementary = emptyList()
+        )
+
+        // All asked
+        Assert.assertTrue(requirements.isResourceActive { true })
+
+        // All asked, except for ActiveCaloriesBurnedRecord::class
+        Assert.assertFalse(requirements.isResourceActive { type -> type != ActiveCaloriesBurnedRecord::class })
+
+        // All have not been asked
+        Assert.assertFalse(requirements.isResourceActive { false })
+    }
+
+    @Test
+    fun `RecordTypeRequirements SomeRequiredSomeOptionalTypes`() {
+        val requirements = RecordTypeRequirements (
+            required = listOf(
+                StepsRecord::class,
+                SpeedRecord::class,
+            ),
+            optional = listOf(
+                ActiveCaloriesBurnedRecord::class,
+            ),
+            supplementary = emptyList()
+        )
+
+        // All asked
+        Assert.assertTrue(requirements.isResourceActive { true })
+
+        // Only SpeedRecord::class has been asked
+        Assert.assertFalse(requirements.isResourceActive { type -> type == SpeedRecord::class })
+
+        // All except ActiveCaloriesBurnedRecord::class have been asked
+        Assert.assertTrue(requirements.isResourceActive { type -> type != ActiveCaloriesBurnedRecord::class })
+
+        // All have not been asked
+        Assert.assertFalse(requirements.isResourceActive { false })
+    }
+
+    @Test
+    fun `RecordTypeRequirements noRequiredMultipleOptionalTypes`() {
+        val requirements = RecordTypeRequirements (
+            required = emptyList(),
+            optional = listOf(
+                StepsRecord::class,
+                ActiveCaloriesBurnedRecord::class,
+                SpeedRecord::class,
+            ),
+            supplementary = emptyList()
+        )
+
+        // All asked
+        Assert.assertTrue(requirements.isResourceActive { true })
+
+        // Only ActiveCaloriesBurnedRecord::class has been asked
+        Assert.assertTrue(requirements.isResourceActive { type -> type == ActiveCaloriesBurnedRecord::class })
+
+        // All have not been asked
+        Assert.assertFalse(requirements.isResourceActive { false })
+    }
+
+    @Test
+    fun `RecordTypeRequirements empty`() {
+        val requirements = RecordTypeRequirements (
+            required = emptyList(),
+            optional = emptyList(),
+            supplementary = emptyList()
+        )
+
+        Assert.assertFalse(requirements.isResourceActive { true })
+        Assert.assertFalse(requirements.isResourceActive { false })
+    }
+
+
+    @Test
+    fun `RecordTypeRequirements does_not_overlap`() {
+        val claimedObjectTypes = mutableSetOf<KClass<out Record>>()
+        val remappedResources = VitalResource.values().mapTo(mutableSetOf()) { it.remapped() }
+
+        for (resource in remappedResources) {
+            val requirements = resource.wrapped.recordTypeDependencies()
+
+            val isNonoverlapping = requirements.required.intersect(claimedObjectTypes).isEmpty()
+                    && requirements.optional.intersect(claimedObjectTypes).isEmpty()
+
+            Assert.assertTrue(
+                "$resource overlaps with another VitalResource.",
+                isNonoverlapping
+            )
+
+            // NOTE = A VitalResource can declare `requirements.supplementary` that overlaps with other
+            //       resource.
+            claimedObjectTypes.addAll(requirements.required)
+            claimedObjectTypes.addAll(requirements.optional)
+        }
+    }
+}


### PR DESCRIPTION
Health Connect uses a similar permission model as HealthKit. This means issues we encountered with HealthKit permission modelling are also applicable to Health Connect.

This PR ports the solutions over from the iOS SDK:

* HealthKitObjectTypeRequirements (now as `RecordTypeRequirements`)
    * from https://github.com/tryVital/vital-ios/pull/120 and https://github.com/tryVital/vital-ios/pull/135
* RemappedVitalResource
    * from https://github.com/tryVital/vital-ios/pull/132