### PR TITLE
VIT-6652: Rename all summary & timeseries POST endpoint models to Local*

### DIFF
--- a/VitalClient/src/main/java/io/tryvital/client/services/VitalPrivateService.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/VitalPrivateService.kt
@@ -4,13 +4,13 @@ import ManualProviderRequest
 import ManualProviderResponse
 import UserSDKSyncStateBody
 import UserSDKSyncStateResponse
-import io.tryvital.client.services.data.ActivityPayload
-import io.tryvital.client.services.data.BloodPressureSamplePayload
-import io.tryvital.client.services.data.BodyPayload
+import io.tryvital.client.services.data.LocalActivity
+import io.tryvital.client.services.data.LocalBloodPressureSample
+import io.tryvital.client.services.data.LocalBody
 import io.tryvital.client.services.data.ManualProviderSlug
-import io.tryvital.client.services.data.ProfilePayload
-import io.tryvital.client.services.data.QuantitySamplePayload
-import io.tryvital.client.services.data.SleepPayload
+import io.tryvital.client.services.data.LocalProfile
+import io.tryvital.client.services.data.LocalQuantitySample
+import io.tryvital.client.services.data.LocalSleep
 import io.tryvital.client.services.data.SummaryPayload
 import io.tryvital.client.services.data.TimeseriesPayload
 import io.tryvital.client.services.data.WorkoutPayload
@@ -47,38 +47,38 @@ interface VitalPrivateService {
     @POST("summary/activity/{user_id}")
     suspend fun addActivities(
         @Path("user_id") userId: String,
-        @Body body: SummaryPayload<List<ActivityPayload>>
+        @Body body: SummaryPayload<List<LocalActivity>>
     ): Response<Unit>
 
     @POST("summary/profile/{user_id}")
     suspend fun addProfile(
         @Path("user_id") userId: String,
-        @Body body: SummaryPayload<ProfilePayload>
+        @Body body: SummaryPayload<LocalProfile>
     ): Response<Unit>
 
     @POST("summary/body/{user_id}")
     suspend fun addBody(
         @Path("user_id") userId: String,
-        @Body body: SummaryPayload<BodyPayload>
+        @Body body: SummaryPayload<LocalBody>
     ): Response<Unit>
 
     @POST("summary/sleep/{user_id}")
     suspend fun addSleeps(
         @Path("user_id") userId: String,
-        @Body body: SummaryPayload<List<SleepPayload>>
+        @Body body: SummaryPayload<List<LocalSleep>>
     ): Response<Unit>
 
     @POST("timeseries/{user_id}/{resource}")
     suspend fun timeseriesPost(
         @Path("user_id") userId: String,
         @Path("resource", encoded = true) resource: String,
-        @Body payload: TimeseriesPayload<List<QuantitySamplePayload>>
+        @Body payload: TimeseriesPayload<List<LocalQuantitySample>>
     ): Response<Unit>
 
     @POST("timeseries/{user_id}/blood_pressure")
     suspend fun bloodPressureTimeseriesPost(
         @Path("user_id") userId: String,
-        @Body payload: TimeseriesPayload<List<BloodPressureSamplePayload>>
+        @Body payload: TimeseriesPayload<List<LocalBloodPressureSample>>
     ): Response<Unit>
 
     companion object {

--- a/VitalClient/src/main/java/io/tryvital/client/services/data/Summary.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/services/data/Summary.kt
@@ -2,9 +2,10 @@ package io.tryvital.client.services.data
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import io.tryvital.client.services.VitalPrivateApi
 import java.time.Instant
-import java.util.*
 
+// @VitalPrivateApi
 @JsonClass(generateAdapter = true)
 data class SummaryPayload<T>(
     @Json(name = "stage")
@@ -21,6 +22,7 @@ data class SummaryPayload<T>(
     val data: T
 )
 
+// @VitalPrivateApi
 @JsonClass(generateAdapter = true)
 data class WorkoutPayload(
     @Json(name = "id")
@@ -40,31 +42,33 @@ data class WorkoutPayload(
     @Json(name = "distance")
     val distanceInMeter: Double,
     @Json(name = "heart_rate")
-    val heartRate: List<QuantitySamplePayload>,
+    val heartRate: List<LocalQuantitySample>,
     @Json(name = "respiratory_rate")
-    val respiratoryRate: List<QuantitySamplePayload>
+    val respiratoryRate: List<LocalQuantitySample>
 )
 
+// @VitalPrivateApi
 @JsonClass(generateAdapter = true)
-data class ActivityPayload(
+data class LocalActivity(
     @Json(name = "day_summary")
     val daySummary: ActivityDaySummary?,
     @Json(name = "active_energy_burned")
-    val activeEnergyBurned: List<QuantitySamplePayload>,
+    val activeEnergyBurned: List<LocalQuantitySample>,
     @Json(name = "basal_energy_burned")
-    val basalEnergyBurned: List<QuantitySamplePayload>,
+    val basalEnergyBurned: List<LocalQuantitySample>,
     @Json(name = "steps")
-    val steps: List<QuantitySamplePayload>,
+    val steps: List<LocalQuantitySample>,
     @Json(name = "distance_walking_running")
-    val distanceWalkingRunning: List<QuantitySamplePayload>,
+    val distanceWalkingRunning: List<LocalQuantitySample>,
     @Json(name = "vo2_max")
-    val vo2Max: List<QuantitySamplePayload>,
+    val vo2Max: List<LocalQuantitySample>,
     @Json(name = "floors_climbed")
-    val floorsClimbed: List<QuantitySamplePayload>,
+    val floorsClimbed: List<LocalQuantitySample>,
 )
 
+// @VitalPrivateApi
 @JsonClass(generateAdapter = true)
-data class ProfilePayload(
+data class LocalProfile(
     @Json(name = "biological_sex")
     val biologicalSex: String?,
     @Json(name = "date_of_birth")
@@ -73,16 +77,18 @@ data class ProfilePayload(
     val heightInCm: Int?,
 )
 
+// @VitalPrivateApi
 @JsonClass(generateAdapter = true)
-data class BodyPayload(
+data class LocalBody(
     @Json(name = "body_mass")
-    val bodyMass: List<QuantitySamplePayload>,
+    val bodyMass: List<LocalQuantitySample>,
     @Json(name = "body_fat_percentage")
-    val bodyFatPercentage: List<QuantitySamplePayload>,
+    val bodyFatPercentage: List<LocalQuantitySample>,
 )
 
+// @VitalPrivateApi
 @JsonClass(generateAdapter = true)
-data class SleepPayload(
+data class LocalSleep(
     @Json(name = "id")
     val id: String,
     @Json(name = "start_date")
@@ -94,19 +100,19 @@ data class SleepPayload(
     @Json(name = "product_type")
     val deviceModel: String?,
     @Json(name = "heart_rate")
-    val heartRate: List<QuantitySamplePayload>,
+    val heartRate: List<LocalQuantitySample>,
     @Json(name = "resting_heart_rate")
-    val restingHeartRate: List<QuantitySamplePayload>,
+    val restingHeartRate: List<LocalQuantitySample>,
     @Json(name = "heart_rate_variability")
-    val heartRateVariability: List<QuantitySamplePayload>,
+    val heartRateVariability: List<LocalQuantitySample>,
     @Json(name = "oxygen_saturation")
-    val oxygenSaturation: List<QuantitySamplePayload>,
+    val oxygenSaturation: List<LocalQuantitySample>,
     @Json(name = "respiratory_rate")
-    val respiratoryRate: List<QuantitySamplePayload>,
+    val respiratoryRate: List<LocalQuantitySample>,
 )
 
 @JsonClass(generateAdapter = true)
-data class QuantitySamplePayload(
+data class LocalQuantitySample(
     @Json(name = "id")
     val id: String? = null,
     @Json(name = "value")
@@ -128,13 +134,13 @@ data class QuantitySamplePayload(
 )
 
 @JsonClass(generateAdapter = true)
-data class BloodPressureSamplePayload(
+data class LocalBloodPressureSample(
     @Json(name = "systolic")
-    val systolic: QuantitySamplePayload,
+    val systolic: LocalQuantitySample,
     @Json(name = "diastolic")
-    val diastolic: QuantitySamplePayload,
+    val diastolic: LocalQuantitySample,
     @Json(name = "pulse")
-    val pulse: QuantitySamplePayload?,
+    val pulse: LocalQuantitySample?,
 )
 
 

--- a/VitalClient/src/test/java/io/tryvital/client/SummaryServiceTest.kt
+++ b/VitalClient/src/test/java/io/tryvital/client/SummaryServiceTest.kt
@@ -81,7 +81,7 @@ class SummaryServiceTest {
                 startDate = null,
                 endDate = null,
                 timeZoneId = null,
-                data = ProfilePayload(
+                data = LocalProfile(
                     biologicalSex = "not_set",
                     dateOfBirth = null,
                     heightInCm = 188,
@@ -109,7 +109,7 @@ class SummaryServiceTest {
                 startDate = null,
                 endDate = null,
                 timeZoneId = null,
-                data = BodyPayload(
+                data = LocalBody(
                     bodyMass = emptyList(),
                     bodyFatPercentage = emptyList()
                 )

--- a/VitalDevices/src/main/java/io/tryvital/vitaldevices/VitalDeviceManager.kt
+++ b/VitalDevices/src/main/java/io/tryvital/vitaldevices/VitalDeviceManager.kt
@@ -8,7 +8,6 @@ import android.content.*
 import android.content.Context.BLUETOOTH_SERVICE
 import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.os.Build
-import io.tryvital.client.services.data.QuantitySamplePayload
 import io.tryvital.client.utils.VitalLogger
 import io.tryvital.vitaldevices.devices.*
 import kotlinx.coroutines.channels.awaitClose

--- a/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/Libre1Reader.kt
+++ b/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/Libre1Reader.kt
@@ -3,7 +3,7 @@ package io.tryvital.vitaldevices.devices
 import android.app.Activity
 import android.content.pm.PackageManager.PERMISSION_GRANTED
 import io.tryvital.client.services.data.ManualProviderSlug
-import io.tryvital.client.services.data.QuantitySamplePayload
+import io.tryvital.client.services.data.LocalQuantitySample
 import io.tryvital.vitaldevices.PermissionMissing
 import io.tryvital.vitaldevices.devices.nfc.Glucose
 import io.tryvital.vitaldevices.devices.nfc.NFC
@@ -13,7 +13,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
-import java.util.Date
 
 enum class Libre1SensorState {
     Unknown,
@@ -54,7 +53,7 @@ data class Libre1Sensor(
 }
 
 data class Libre1Read(
-    val samples: List<QuantitySamplePayload>,
+    val samples: List<LocalQuantitySample>,
     val sensor: Libre1Sensor,
 )
 
@@ -92,8 +91,8 @@ internal class Libre1ReaderImpl(private val activity: Activity): Libre1Reader {
     }
 }
 
-private fun quantitySampleFromGlucose(glucose: Glucose): QuantitySamplePayload {
-    return QuantitySamplePayload(
+private fun quantitySampleFromGlucose(glucose: Glucose): LocalQuantitySample {
+    return LocalQuantitySample(
         id = glucose.id.toString(),
         value = glucose.valueUnit,
         startDate = glucose.date,

--- a/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/postSamples.kt
+++ b/VitalDevices/src/main/java/io/tryvital/vitaldevices/devices/postSamples.kt
@@ -6,10 +6,10 @@ import android.content.Context
 import io.tryvital.client.VitalClient
 import io.tryvital.client.createConnectedSourceIfNotExist
 import io.tryvital.client.services.VitalPrivateApi
-import io.tryvital.client.services.data.BloodPressureSamplePayload
+import io.tryvital.client.services.data.LocalBloodPressureSample
 import io.tryvital.client.services.data.DataStage
 import io.tryvital.client.services.data.ManualProviderSlug
-import io.tryvital.client.services.data.QuantitySamplePayload
+import io.tryvital.client.services.data.LocalQuantitySample
 import io.tryvital.client.services.data.TimeseriesPayload
 import io.tryvital.client.utils.VitalLogger
 import kotlinx.coroutines.DelicateCoroutinesApi
@@ -17,7 +17,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import java.util.TimeZone
 
-internal fun postGlucoseSamples(context: Context, provider: ManualProviderSlug, samples: List<QuantitySamplePayload>) {
+internal fun postGlucoseSamples(context: Context, provider: ManualProviderSlug, samples: List<LocalQuantitySample>) {
     if (samples.isEmpty()) {
         return
     }
@@ -33,7 +33,7 @@ internal fun postGlucoseSamples(context: Context, provider: ManualProviderSlug, 
     }
 }
 
-internal fun postBloodPressureSamples(context: Context, provider: ManualProviderSlug, samples: List<BloodPressureSamplePayload>) {
+internal fun postBloodPressureSamples(context: Context, provider: ManualProviderSlug, samples: List<LocalBloodPressureSample>) {
     if (samples.isEmpty()) {
         return
     }
@@ -49,7 +49,7 @@ internal fun postBloodPressureSamples(context: Context, provider: ManualProvider
     }
 }
 
-private suspend fun postGlucoseSamplesImpl(context: Context, provider: ManualProviderSlug, samples: List<QuantitySamplePayload>) {
+private suspend fun postGlucoseSamplesImpl(context: Context, provider: ManualProviderSlug, samples: List<LocalQuantitySample>) {
     val client = VitalClient.getOrCreate(context)
     if (VitalClient.Status.SignedIn !in VitalClient.status) {
         return
@@ -70,7 +70,7 @@ private suspend fun postGlucoseSamplesImpl(context: Context, provider: ManualPro
     )
 }
 
-private suspend fun postBloodPressureSamplesImpl(context: Context, provider: ManualProviderSlug, samples: List<BloodPressureSamplePayload>) {
+private suspend fun postBloodPressureSamplesImpl(context: Context, provider: ManualProviderSlug, samples: List<LocalBloodPressureSample>) {
     val client = VitalClient.getOrCreate(context)
     if (VitalClient.Status.SignedIn !in VitalClient.status) {
         return

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/Activity.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/Activity.kt
@@ -1,7 +1,7 @@
 package io.tryvital.vitalhealthconnect.model.processedresource
 
 import io.tryvital.client.services.data.ActivityDaySummary
-import io.tryvital.client.services.data.ActivityPayload
+import io.tryvital.client.services.data.LocalActivity
 
 data class Activity(
     val daySummary: ActivityDaySummary?,
@@ -12,8 +12,8 @@ data class Activity(
     val vo2Max: List<QuantitySample>,
     val floorsClimbed: List<QuantitySample>,
 ) {
-    fun toActivityPayload(): ActivityPayload {
-        return ActivityPayload(
+    fun toActivityPayload(): LocalActivity {
+        return LocalActivity(
             daySummary = daySummary,
             activeEnergyBurned = activeEnergyBurned.map { it.toQuantitySamplePayload() },
             basalEnergyBurned = basalEnergyBurned.map { it.toQuantitySamplePayload() },

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/BloodPressureSample.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/BloodPressureSample.kt
@@ -1,13 +1,13 @@
 package io.tryvital.vitalhealthconnect.model.processedresource
 
-import io.tryvital.client.services.data.BloodPressureSamplePayload
+import io.tryvital.client.services.data.LocalBloodPressureSample
 
 data class BloodPressureSample(
     val systolic: QuantitySample,
     val diastolic: QuantitySample,
     val pulse: QuantitySample?,
 ) {
-    fun toBloodPressurePayload() = BloodPressureSamplePayload(
+    fun toBloodPressurePayload() = LocalBloodPressureSample(
         systolic = systolic.toQuantitySamplePayload(),
         diastolic = diastolic.toQuantitySamplePayload(),
         pulse = pulse?.toQuantitySamplePayload(),

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/ProcessedResourceData.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/ProcessedResourceData.kt
@@ -1,10 +1,9 @@
 package io.tryvital.vitalhealthconnect.model.processedresource
 
-import io.tryvital.client.services.data.BodyPayload
+import io.tryvital.client.services.data.LocalBody
 import io.tryvital.client.services.data.IngestibleTimeseriesResource
-import io.tryvital.client.services.data.ProfilePayload
+import io.tryvital.client.services.data.LocalProfile
 import java.time.Instant
-import java.util.Date
 
 sealed class ProcessedResourceData {
     data class Summary(val summaryData: SummaryData) : ProcessedResourceData()
@@ -61,8 +60,8 @@ sealed class SummaryData {
         val heightInCm: Int?,
     ) : SummaryData() {
 
-        fun toProfilePayload(): ProfilePayload {
-            return ProfilePayload(
+        fun toProfilePayload(): LocalProfile {
+            return LocalProfile(
                 biologicalSex = biologicalSex,
                 dateOfBirth = dateOfBirth,
                 heightInCm = heightInCm,
@@ -83,8 +82,8 @@ sealed class SummaryData {
         val bodyFatPercentage: List<QuantitySample>,
     ) : SummaryData() {
 
-        fun toBodyPayload(): BodyPayload {
-            return BodyPayload(
+        fun toBodyPayload(): LocalBody {
+            return LocalBody(
                 bodyMass = bodyMass.map { it.toQuantitySamplePayload() },
                 bodyFatPercentage = bodyFatPercentage.map { it.toQuantitySamplePayload() },
             )

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/QuantitySample.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/QuantitySample.kt
@@ -1,8 +1,7 @@
 package io.tryvital.vitalhealthconnect.model.processedresource
 
-import io.tryvital.client.services.data.QuantitySamplePayload
+import io.tryvital.client.services.data.LocalQuantitySample
 import java.time.Instant
-import java.util.Date
 
 data class QuantitySample(
     val id: String? = null,
@@ -15,7 +14,7 @@ data class QuantitySample(
     val type: String? = null,
     val metadata: String? = null,
 ) {
-    fun toQuantitySamplePayload() = QuantitySamplePayload(
+    fun toQuantitySamplePayload() = LocalQuantitySample(
         id = id,
         value = value,
         unit = unit,

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/Sleep.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/processedresource/Sleep.kt
@@ -1,8 +1,7 @@
 package io.tryvital.vitalhealthconnect.model.processedresource
 
-import io.tryvital.client.services.data.SleepPayload
+import io.tryvital.client.services.data.LocalSleep
 import java.time.Instant
-import java.util.Date
 
 data class Sleep(
     val id: String,
@@ -17,8 +16,8 @@ data class Sleep(
     val respiratoryRate: List<QuantitySample>,
     val stages: SleepStages,
 ) {
-    fun toSleepPayload(): SleepPayload {
-        return SleepPayload(
+    fun toSleepPayload(): LocalSleep {
+        return LocalSleep(
             id = id,
             startDate = startDate,
             endDate = endDate,

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordUploader.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/records/RecordUploader.kt
@@ -4,20 +4,19 @@ package io.tryvital.vitalhealthconnect.records
 
 import io.tryvital.client.VitalClient
 import io.tryvital.client.services.VitalPrivateApi
-import io.tryvital.client.services.data.ActivityPayload
-import io.tryvital.client.services.data.BloodPressureSamplePayload
-import io.tryvital.client.services.data.BodyPayload
+import io.tryvital.client.services.data.LocalActivity
+import io.tryvital.client.services.data.LocalBloodPressureSample
+import io.tryvital.client.services.data.LocalBody
 import io.tryvital.client.services.data.DataStage
 import io.tryvital.client.services.data.IngestibleTimeseriesResource
 import io.tryvital.client.services.data.ManualProviderSlug
-import io.tryvital.client.services.data.ProfilePayload
-import io.tryvital.client.services.data.QuantitySamplePayload
-import io.tryvital.client.services.data.SleepPayload
+import io.tryvital.client.services.data.LocalProfile
+import io.tryvital.client.services.data.LocalQuantitySample
+import io.tryvital.client.services.data.LocalSleep
 import io.tryvital.client.services.data.SummaryPayload
 import io.tryvital.client.services.data.TimeseriesPayload
 import io.tryvital.client.services.data.WorkoutPayload
 import java.time.Instant
-import java.util.Date
 
 
 interface RecordUploader {
@@ -27,7 +26,7 @@ interface RecordUploader {
         startDate: Instant?,
         endDate: Instant?,
         timeZoneId: String?,
-        sleepPayloads: List<SleepPayload>,
+        sleepPayloads: List<LocalSleep>,
         stage: DataStage = DataStage.Daily,
     )
 
@@ -36,7 +35,7 @@ interface RecordUploader {
         startDate: Instant?,
         endDate: Instant?,
         timeZoneId: String?,
-        bodyPayload: BodyPayload,
+        bodyPayload: LocalBody,
         stage: DataStage = DataStage.Daily,
     )
 
@@ -45,7 +44,7 @@ interface RecordUploader {
         startDate: Instant?,
         endDate: Instant?,
         timeZoneId: String?,
-        profilePayload: ProfilePayload,
+        profilePayload: LocalProfile,
         stage: DataStage = DataStage.Daily,
     )
 
@@ -54,7 +53,7 @@ interface RecordUploader {
         startDate: Instant?,
         endDate: Instant?,
         timeZoneId: String?,
-        activityPayloads: List<ActivityPayload>,
+        activityPayloads: List<LocalActivity>,
         stage: DataStage = DataStage.Daily,
     )
 
@@ -72,7 +71,7 @@ interface RecordUploader {
         startDate: Instant?,
         endDate: Instant?,
         timeZoneId: String?,
-        bloodPressurePayloads: List<BloodPressureSamplePayload>,
+        bloodPressurePayloads: List<LocalBloodPressureSample>,
         stage: DataStage = DataStage.Daily,
     )
 
@@ -82,7 +81,7 @@ interface RecordUploader {
         startDate: Instant?,
         endDate: Instant?,
         timeZoneId: String?,
-        quantitySamples: List<QuantitySamplePayload>,
+        quantitySamples: List<LocalQuantitySample>,
         stage: DataStage = DataStage.Daily,
     )
 }
@@ -93,7 +92,7 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         startDate: Instant?,
         endDate: Instant?,
         timeZoneId: String?,
-        sleepPayloads: List<SleepPayload>,
+        sleepPayloads: List<LocalSleep>,
         stage: DataStage,
     ) {
         vitalClient.vitalPrivateService.addSleeps(
@@ -113,7 +112,7 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         startDate: Instant?,
         endDate: Instant?,
         timeZoneId: String?,
-        bodyPayload: BodyPayload,
+        bodyPayload: LocalBody,
         stage: DataStage,
     ) {
         vitalClient.vitalPrivateService.addBody(
@@ -133,7 +132,7 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         startDate: Instant?,
         endDate: Instant?,
         timeZoneId: String?,
-        profilePayload: ProfilePayload,
+        profilePayload: LocalProfile,
         stage: DataStage,
     ) {
         vitalClient.vitalPrivateService.addProfile(
@@ -153,7 +152,7 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         startDate: Instant?,
         endDate: Instant?,
         timeZoneId: String?,
-        activityPayloads: List<ActivityPayload>,
+        activityPayloads: List<LocalActivity>,
         stage: DataStage,
     ) {
         vitalClient.vitalPrivateService.addActivities(
@@ -194,7 +193,7 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         startDate: Instant?,
         endDate: Instant?,
         timeZoneId: String?,
-        quantitySamples: List<QuantitySamplePayload>,
+        quantitySamples: List<LocalQuantitySample>,
         stage: DataStage,
     ) {
         vitalClient.vitalPrivateService.timeseriesPost(
@@ -214,7 +213,7 @@ class VitalClientRecordUploader(private val vitalClient: VitalClient) : RecordUp
         startDate: Instant?,
         endDate: Instant?,
         timeZoneId: String?,
-        bloodPressurePayloads: List<BloodPressureSamplePayload>,
+        bloodPressurePayloads: List<LocalBloodPressureSample>,
         stage: DataStage,
     ) {
         vitalClient.vitalPrivateService.bloodPressureTimeseriesPost(

--- a/app/src/main/java/io/tryvital/sample/ui/device/DeviceModel.kt
+++ b/app/src/main/java/io/tryvital/sample/ui/device/DeviceModel.kt
@@ -7,8 +7,8 @@ import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import io.tryvital.client.services.data.BloodPressureSamplePayload
-import io.tryvital.client.services.data.QuantitySamplePayload
+import io.tryvital.client.services.data.LocalBloodPressureSample
+import io.tryvital.client.services.data.LocalQuantitySample
 import io.tryvital.vitaldevices.*
 import io.tryvital.vitaldevices.devices.Libre1Reader
 import kotlinx.coroutines.*
@@ -175,8 +175,8 @@ class DeviceViewModel(
 data class BluetoothViewModelState(
     val device: DeviceModel,
     val scannedDevices: List<ScannedDevice>,
-    val samples: List<QuantitySamplePayload>,
-    val bloodPressureSamples: List<BloodPressureSamplePayload>,
+    val samples: List<LocalQuantitySample>,
+    val bloodPressureSamples: List<LocalBloodPressureSample>,
     val canScan: Boolean,
     val isScanning: Boolean,
     val isReading: Boolean,


### PR DESCRIPTION
Align with iOS:
* QuantitySamplePayload -> LocalQuantitySample 
* BloodPressureSamplePayload -> LocalBloodPressureSample

Android specific:
* `*Payload` -> `Local*` e.g. SleepPayload -> LocalSleep
* (iOS modelled these differently where everything is nested under `ProcessedResourceData`. I don't see a strong need to change this on iOS)

The Local- prefix is here to avoid any clashes with Vital API response models, and also a very obvious cue of these Local- models being different from the API response models as well.