### PR TITLE
VIT-6664: Android: Try to create connected source on successful Ask

### DIFF
--- a/VitalClient/src/main/java/io/tryvital/client/userConnectedSources.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/userConnectedSources.kt
@@ -18,17 +18,6 @@ fun VitalClient.hasUserConnectedTo(provider: ProviderSlug): Boolean {
 suspend fun VitalClient.createConnectedSourceIfNotExist(provider: ManualProviderSlug) {
     val userId = VitalClient.checkUserId()
     val slug = provider.toProviderSlug()
-    if (hasUserConnectedTo(slug)) {
-        // Local Hit: The client has witnessed a valid connected source for this provider before.
-        return
-    }
-
-    // Local Miss: First try to query the user's current set of connected sources.
-    val sources = userConnections()
-    if (sources.any { it.slug == slug }) {
-        // Remote Hit: The client has connected to this provider.
-        return
-    }
 
     fun recordConnectedSourceExistence() {
         sharedPreferences.edit()
@@ -37,7 +26,7 @@ suspend fun VitalClient.createConnectedSourceIfNotExist(provider: ManualProvider
     }
 
     try {
-        // Remote Miss: Try to create the manual connected source.
+        // Try to create the manual connected source.
         vitalPrivateService.manualProvider(
             provider = provider,
             request = ManualProviderRequest(userId = userId)

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
@@ -39,7 +39,7 @@ import kotlin.reflect.KClass
 class VitalHealthConnectManager private constructor(
     internal val context: Context,
     private val healthConnectClientProvider: HealthConnectClientProvider,
-    private val vitalClient: VitalClient,
+    internal val vitalClient: VitalClient,
     private val recordReader: RecordReader,
     private val recordProcessor: RecordProcessor,
 ) {


### PR DESCRIPTION
Proactively try to create a connected source, after the user has gone through the Health Connect permission flow successfully (i.e. did not cancel the prompt).

Also remove the `checkConnectedSource` caching (a persistent flag tracking if the CS has been created):
* In the Health Connect sync process, we would call this as part of the LocalSyncState revalidation logic, so it is already covered by the same 4-hour TTL.
* In Devices SDK, the reading happens somewhat sparingly in absence of BLE background scanning and auto-send support. So it is fine to have it calling the API without caching.