### PR TITLE
VIT-6677: Request hourly activity totals from Health Connect

### DIFF
--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/HCActivitySummary.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/HCActivitySummary.kt
@@ -1,6 +1,7 @@
 package io.tryvital.vitalhealthconnect.model
 
 import io.tryvital.client.services.data.ActivityDaySummary
+import io.tryvital.client.services.data.LocalQuantitySample
 import java.time.LocalDate
 
 internal data class HCActivitySummary(
@@ -39,3 +40,10 @@ internal data class HCActivitySummary(
         exerciseTime = totalExerciseDuration?.toDouble(),
     )
 }
+
+internal data class HCActivityHourlyTotals(
+    val activeCalories: Map<LocalDate, List<LocalQuantitySample>> = emptyMap(),
+    val steps: Map<LocalDate, List<LocalQuantitySample>> = emptyMap(),
+    val distance: Map<LocalDate, List<LocalQuantitySample>> = emptyMap(),
+    val floorsClimbed: Map<LocalDate, List<LocalQuantitySample>> = emptyMap(),
+)

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/HCQuantitySample.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/HCQuantitySample.kt
@@ -11,17 +11,18 @@ fun quantitySample(
     unit: String,
     startDate: Instant,
     endDate: Instant,
-    metadata: Metadata,
+    metadata: Metadata? = null,
+    sourceType: SourceType? = null,
 ): LocalQuantitySample {
     return LocalQuantitySample(
-        id = metadata.id,
+        id = metadata?.id,
         value = value,
         unit = unit,
         startDate = startDate,
         endDate = endDate,
-        type = metadata.inferredSourceType,
-        sourceBundle = metadata.dataOrigin.packageName,
-        deviceModel = metadata.device?.model,
+        type = sourceType ?: metadata?.inferredSourceType,
+        sourceBundle = metadata?.dataOrigin?.packageName,
+        deviceModel = metadata?.device?.model,
     )
 }
 


### PR DESCRIPTION
Request hourly activity totals from Health Connect using the `aggregateGroupByDuration` API.

One `AggregateGroupByDurationRequest` is made for the entire time range during we have discovered sample insertions.

https://developer.android.com/reference/kotlin/androidx/health/connect/client/request/AggregateGroupByDurationRequest