### PR TITLE
VIT-7220: Migrate away from androidx-security-crypto

### DIFF
--- a/VitalClient/src/main/java/io/tryvital/client/jwt/VitalJWTAuth.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/jwt/VitalJWTAuth.kt
@@ -5,14 +5,11 @@ import android.content.SharedPreferences
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
 import io.tryvital.client.Environment
 import io.tryvital.client.Region
-import io.tryvital.client.VITAL_ENCRYPTED_PERFS_FILE_NAME
-import io.tryvital.client.createEncryptedSharedPreferences
+import io.tryvital.client.createLocalStorage
 import io.tryvital.client.utils.InstantJsonAdapter
 import io.tryvital.client.utils.VitalLogger
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -32,7 +29,6 @@ import okio.ByteString.Companion.decodeBase64
 import java.io.IOException
 import java.lang.IllegalArgumentException
 import java.time.Instant
-import java.util.Date
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -98,15 +94,7 @@ internal class VitalJWTAuth(
                 return shared
             }
 
-            val sharedPreferences = try {
-                createEncryptedSharedPreferences(appContext)
-            } catch (e: Exception) {
-                VitalLogger.getOrCreate().logE(
-                    "Failed to decrypt VitalJWTAuth preferences, re-creating it", e
-                )
-                appContext.deleteSharedPreferences(VITAL_ENCRYPTED_PERFS_FILE_NAME)
-                createEncryptedSharedPreferences(appContext)
-            }
+            val sharedPreferences = createLocalStorage(appContext)
 
             this.shared = VitalJWTAuth(
                 preferences = sharedPreferences

--- a/VitalClient/src/main/java/io/tryvital/client/utils/logger.kt
+++ b/VitalClient/src/main/java/io/tryvital/client/utils/logger.kt
@@ -1,6 +1,7 @@
 package io.tryvital.client.utils
 
 import android.util.Log
+import io.tryvital.client.BuildConfig
 
 const val VITAL_LOGGER = "vital-logger"
 
@@ -38,6 +39,7 @@ class VitalLogger private constructor() {
         fun getOrCreate(): VitalLogger = synchronized(VitalLogger) {
             if (instance == null) {
                 instance = VitalLogger()
+                instance!!.enabled = BuildConfig.DEBUG
             }
             return instance!!
         }


### PR DESCRIPTION
Two issues:

1. Android Keystore not reliable across the whole Android OEM ecosystem, where some Googler suggested it is OEM firmware level issues. This in turn affects the reliability of a downstream component like `EncryptedSharedPreferences` in androidx-security-crypto.
    * https://github.com/tink-crypto/tink/issues/535
    * https://issuetracker.google.com/issues/176215143

2. Google decided to [deprecate the androidx-security-crypto library](https://developer.android.com/reference/androidx/security/crypto/EncryptedSharedPreferences).

This PR migrates away from androidx-security-crypto, and removes the usage of `EncryptedSharedPreferences`. Existing `EncryptedSharedPreferences` would be copied into a new `SharedPreferences` in a one-off migration.