### PR TITLE
VIT-7773: Remove dependency on Android Core Library Desugaring

### DIFF
--- a/VitalClient/build.gradle
+++ b/VitalClient/build.gradle
@@ -10,7 +10,7 @@ android {
     namespace 'io.tryvital.client'
 
     defaultConfig {
-        minSdk 24
+        minSdk 26
         targetSdk 34
 
         aarMetadata {
@@ -39,8 +39,6 @@ android {
     }
 
     compileOptions {
-        coreLibraryDesugaringEnabled true
-
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -82,8 +80,6 @@ dependencies {
     testImplementation "org.mockito:mockito-inline:$mockito_inline"
     testImplementation "com.squareup.okhttp3:mockwebserver:$mockwebserver"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinx_coroutines_test"
-
-    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$desugar_jdk_libs"
 }
 
 publishing {

--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/VitalResource.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/model/VitalResource.kt
@@ -171,9 +171,7 @@ value class RemappedVitalResource(val wrapped: VitalResource) {
  * compute Activity Day Summary & pull individual samples adaptively in accordance to the permission
  * state.
  */
-internal fun VitalResource.remapped(): RemappedVitalResource = when (this) {
-    else -> RemappedVitalResource(this)
-}
+internal fun VitalResource.remapped(): RemappedVitalResource = RemappedVitalResource(this)
 
 /**
  * VitalResource data dependencies on Health Connect record.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,7 +31,6 @@ android {
     }
 
     compileOptions {
-        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -71,8 +70,6 @@ dependencies {
     implementation project(':VitalClient')
     implementation project(':VitalDevices')
     implementation project(':VitalHealthConnect')
-
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:$desugar_jdk_libs")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin"
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ buildscript {
         // Linked with Kotlin compiler version
         compose_compiler = '1.4.8'
 
-        desugar_jdk_libs = '1.2.3'
         nav = '2.5.3'
         material3 = '1.0.1'
         activity_compose = '1.6.1'


### PR DESCRIPTION
VitalDevices and VitalHealthConnect already requires min SDK 26. There is no need for VitalCore to stay on min SDK 24. 

By moving VitalCore to min SDK 26, which exposes all Java 8 APIs, we can disable Core Library Desugaring entirely.


Note: This probably should result in a major version bump, since it would likely break the app project build.