### PR TITLE
VIT-7878: Always register SDK process lifecycle observer on the main thread

### DIFF
--- a/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
+++ b/VitalHealthConnect/src/main/java/io/tryvital/vitalhealthconnect/VitalHealthConnectManager.kt
@@ -116,14 +116,16 @@ class VitalHealthConnectManager private constructor(
     // 2. cancelling the scope would cancel all running child jobs.
     internal var taskScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
-    var processLifecycleObserver: LifecycleObserver
+    lateinit var processLifecycleObserver: LifecycleObserver
 
     init {
         vitalLogger.logI("VitalHealthConnectManager initialized")
         _status.tryEmit(SyncStatus.Unknown)
 
-        processLifecycleObserver = processLifecycleObserver(this)
-            .also { ProcessLifecycleOwner.get().lifecycle.addObserver(it) }
+        taskScope.launch(Dispatchers.Main.immediate) {
+            processLifecycleObserver = processLifecycleObserver(this@VitalHealthConnectManager)
+                .also { ProcessLifecycleOwner.get().lifecycle.addObserver(it) }
+        }
 
         setupSyncWorkerObservation()
     }


### PR DESCRIPTION
`ProcessLifecycleOwner.addObserver` has a main-thread-only precondition.

Some customers use DI framework and cannot precisely control when they call `VitalHealthConnectManager.getOrCreate`. So they occasionally run into this main-thread-only precondition, due to the SDK's reliance on process lifecycle observer.

We now register the process lifecycle observer using `Dispatchers.Main.immediate`, which:

* If the caller is on the main thread, execute the lambda synchronously
* otherwise, schedule the lambda onto the main thread for async execution.